### PR TITLE
Switch core detection

### DIFF
--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -1,6 +1,6 @@
 module RSpec
 
-  if respond_to?(:configuration)
+  if self.const_get("Core")
 
     # @private
     #

--- a/spec/rspec/warnings_spec.rb
+++ b/spec/rspec/warnings_spec.rb
@@ -74,7 +74,7 @@ describe "rspec warnings and deprecations" do
 
   context "when rspec-core is not available" do
     before do
-      allow(RSpec).to receive(:respond_to?).with(:configuration)
+      allow(RSpec).to receive(:const_get).with("Core")
       reset_and_load_warnings
     end
 


### PR DESCRIPTION
We can't rely on configuration being available when this file is loaded.
So instead we rely on Core being defined.
