### PR TITLE
Remove the safety check for CallerFilter from rspec-core

### DIFF
--- a/spec/rspec/caller_filter_spec.rb
+++ b/spec/rspec/caller_filter_spec.rb
@@ -1,9 +1,4 @@
 require 'spec_helper'
-
-if defined? RSpec::CallerFilter
-  RSpec.send :remove_const, :CallerFilter
-end
-
 require 'rspec/support/caller_filter'
 
 module RSpec


### PR DESCRIPTION
No longer needed since rspec-core now pulls in `CallerFilter` from here.
