### PR TITLE
Defering to `rspec-core` when available without depending on it

### DIFF
--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -1,24 +1,6 @@
 module RSpec
 
-  if defined?(::RSpec::Core)
-
-    # @private
-    #
-    # Used internally to print deprecation warnings
-    def self.deprecate(deprecated, data = {})
-      data[:call_site]  ||= CallerFilter.first_non_rspec_line
-      data[:deprecated] ||= deprecated
-      RSpec.configuration.reporter.deprecation(data)
-    end
-
-    # @private
-    #
-    # Used internally to print deprecation warnings
-    def self.warn_deprecation(message)
-      RSpec.configuration.reporter.deprecation :message => message
-    end
-
-  else
+  unless respond_to?(:deprecate)
 
     # @private
     #
@@ -27,6 +9,9 @@ module RSpec
     def self.deprecate(deprecated, options = {})
       warn_with "DEPRECATION: #{deprecated} is deprecated.", options
     end
+  end
+
+  unless respond_to?(:warn_deprecation)
 
     # @private
     #
@@ -35,7 +20,6 @@ module RSpec
     def self.warn_deprecation(message)
       warn_with "DEPRECATION: \n #{message}"
     end
-
   end
 
   # @private

--- a/spec/rspec/warnings_spec.rb
+++ b/spec/rspec/warnings_spec.rb
@@ -1,29 +1,10 @@
 require "spec_helper"
 require 'rspec/support/spec/in_sub_process'
 
-# Make sure we're using the `rspec-support` CallerFilter
-# can be removed at a later date
-unless RSpec::CallerFilter::RSPEC_LIBS.include? 'support'
-  RSpec.send :remove_const, :CallerFilter
-  require 'rspec/support/caller_filter'
-end
-# end cf cleanup #
-
-# Make sure that we're using the warnings code from `rspec-support`
-# Can be removed at a later date
-%w[rspec/core/warnings rspec/mocks/warnings rspec/expectations/deprecation].each do |file|
-  begin
-    require file
-  rescue LoadError
-  end
-end
-
 module RSpec
   class << self
     undef deprecate        if defined?(RSpec.deprecate)
     undef warn_deprecation if defined?(RSpec.warn_deprecation)
-    undef warning          if defined?(RSpec.warning)
-    undef warn_with        if defined?(RSpec.warn_with)
   end
 end
 # end warnings cleanup #
@@ -33,6 +14,7 @@ describe "rspec warnings and deprecations" do
 
   def run_with_rspec_core
     in_sub_process do
+      load 'rspec/core/warnings.rb'
       load 'rspec/support/warnings.rb'
       yield
     end


### PR DESCRIPTION
Quoting @myronmarston :

> I'm worried that we're creating a circular dependency here: rspec-core depends on this gem, and this gem now implicitly depends on rspec-core, and that could create a maintenance headache. (Consider, for example, what happens when we decide to change the deprecation formatter API: we'll have to coordinate changes in rspec-core and rspec-support).
> 
> Do you think there's a reasonable way to get this to work that doesn't involve creating that circular dependency?
> 
> For example, maybe this gem could just define the core-less version of these methods, and then core can override those definitions. Or here it could define the methods only if defined?(::RSpec::Core) is false, and then rspec-core can take care of defining its versions.
> 
> Thoughts?

My own immediate thoughts are that I'd rather have all this code in `-support` but I can see @myronmarston's concerns. Originally the definition of this didn't depend on a formatter, and even if we were to only define the two deprecation methods if Core wasn't loaded we're splitting the responsibility for this functionality into two places. Which I don't like, however it would still eliminate 2 places (`-mocks` and `-expectations`) which is still a benefit. So...

Thoughts?

/cc @samphippen @alindeman @soulcutter @xaviershay 
