### PR TITLE
Extract stderr isolation to helper

### DIFF
--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -1,10 +1,12 @@
 require 'rspec/support/spec/deprecation_helpers'
+require 'rspec/support/spec/with_isolated_stderr'
 require 'rspec/support/spec/stderr_splitter'
 
 warning_preventer = $stderr = RSpec::Support::StdErrSplitter.new($stderr)
 
 RSpec.configure do |c|
   c.include RSpecHelpers
+  c.include RSpec::Support::WithIsolatedStdErr
   c.before do
     warning_preventer.reset!
   end

--- a/lib/rspec/support/spec/with_isolated_stderr.rb
+++ b/lib/rspec/support/spec/with_isolated_stderr.rb
@@ -1,0 +1,14 @@
+module RSpec
+  module Support
+    module WithIsolatedStdErr
+
+      def with_isolated_stderr
+        original = $stderr
+        $stderr = StringIO.new
+        yield
+        $stderr = original
+      end
+
+    end
+  end
+end

--- a/spec/rspec/support/spec/with_isolated_std_err_spec.rb
+++ b/spec/rspec/support/spec/with_isolated_std_err_spec.rb
@@ -1,0 +1,11 @@
+require 'rspec/support/spec'
+
+describe 'isolating a spec from the stderr splitter' do
+  include RSpec::Support::WithIsolatedStdErr
+
+  it 'allows a spec to output a warning' do
+    with_isolated_stderr do
+      $stderr.puts "Imma gonna warn you"
+    end
+  end
+end


### PR DESCRIPTION
This is useful when we want to generate warnings without being penalised by the stderr splitter.
Simply using `allow(::Kernel).to receive(:warn)` doesn't always seem to work (1.8.7)
