### PR TITLE
Add `setup_simplecov` helper method.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gemspec
 end
 
 ### dep for ci/coverage
-gem 'coveralls', :require => false
-gem 'mime-types', '< 2' if RUBY_VERSION.to_f < 1.9
+gem 'simplecov', '~> 0.8'
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -14,3 +14,33 @@ RSpec.configure do |c|
     warning_preventer.verify_example!(example)
   end
 end
+
+module RSpec::Support::Spec
+  def self.setup_simplecov(&block)
+    return if ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
+
+    # Don't load it when we're running a single isolated
+    # test file rather than the whole suite.
+    return if RSpec.configuration.files_to_run.one?
+
+    # Simplecov emits some ruby warnings when loaded, so silence them.
+    old_verbose, $VERBOSE = $VERBOSE, false
+    require 'simplecov'
+
+    SimpleCov.start do
+      add_filter "./bundle/"
+      add_filter "./tmp/"
+      add_filter do |source_file|
+        # Filter out `spec` directory except when it is under `lib`
+        # (as is the case in rspec-support)
+        source_file.filename.include?('spec') && !source_file.filename.include?('lib')
+      end
+
+      instance_eval(&block) if block
+    end
+  rescue LoadError
+  ensure
+    $VERBOSE = old_verbose
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,2 @@
-if ENV['TRAVIS']
-  require 'simplecov' if RUBY_VERSION.to_f > 1.8
-  require 'coveralls'
-  Coveralls.wear! do
-    add_filter '/bundle/'
-    add_filter '/spec/'
-    add_filter '/tmp/'
-  end
-end
-
 require 'rspec/support/spec'
+RSpec::Support::Spec.setup_simplecov


### PR DESCRIPTION
This provides a simple way to configure simplecov for all our projects.  I have a branch of rspec-expectations that uses this that I want to push later today so I'll probably go ahead and merge this in the near future.  Wanted to make a PR to make everyone aware of it, though.

/cc @xaviershay @JonRowe @soulcutter @samphippen @alindeman 
