### PR TITLE
Add @myronmarstons expect_no_deprecation helper

### DIFF
--- a/lib/rspec/support/spec/deprecation_helpers.rb
+++ b/lib/rspec/support/spec/deprecation_helpers.rb
@@ -1,4 +1,9 @@
 module RSpecHelpers
+
+  def expect_no_deprecation
+    expect(RSpec.configuration.reporter).not_to receive(:deprecation)
+  end
+
   def expect_deprecation_with_call_site(file, line, snippet=//)
     expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
       expect(options[:call_site]).to include([file, line].join(':'))


### PR DESCRIPTION
I noticed @myronmarston adding an addition to the helpers we have already on a 2.99 branch, this pulls it into here for 3.x usage.
