### PR TITLE
Show the example a warning occurred in if nil call site is given.

### DIFF
--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -35,8 +35,11 @@ module RSpec
   def self.warn_with(message, options = {})
     call_site = options.fetch(:call_site) { CallerFilter.first_non_rspec_line }
     message << " Use #{options[:replacement]} instead." if options[:replacement]
-    message << " Called from #{call_site}." if call_site
+    if call_site
+      message << " Called from #{call_site}."
+    elsif RSpec.respond_to?(:current_example) && RSpec.current_example
+      message << " Warning occured in `#{RSpec.current_example.source_location.join(":")}`."
+    end
     ::Kernel.warn message
   end
-
 end

--- a/spec/rspec/support/warnings_spec.rb
+++ b/spec/rspec/support/warnings_spec.rb
@@ -99,6 +99,14 @@ describe "rspec warnings and deprecations" do
         RSpec.send(helper, 'Message', :replacement => 'Replacement')
       end
     end
+
+    it "includes the file and line of the spec if call site is nil" do
+      top_of_spec = __LINE__ - 1
+      run_without_rspec_core do
+        expect(::Kernel).to receive(:warn).with(/Warning occured.*warnings_spec.rb:#{top_of_spec}/)
+        RSpec.send(helper, "bees", :call_site => nil)
+      end
+    end
   end
 
   describe "#warning" do


### PR DESCRIPTION
Sometimes we issue warnings outside of a user's spec, but the warning was caused by something the user did.. An example of this is in: https://github.com/rspec/rspec-mocks/pull/496 where we want to tell the user where the error came from, but we can't really detect where the object was frozen.

This prints that if a nil call site is given.
