### PR TITLE
Extract matchers from rspec-expectations

### DIFF
--- a/lib/rspec/support/spec/matchers.rb
+++ b/lib/rspec/support/spec/matchers.rb
@@ -1,0 +1,15 @@
+module RSpec
+  module Matchers
+    def fail
+      raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    def fail_with(message)
+      raise_error(RSpec::Expectations::ExpectationNotMetError, message)
+    end
+
+    def fail_matching(message)
+      raise_error(RSpec::Expectations::ExpectationNotMetError, /#{Regexp.escape(message)}/)
+    end
+  end
+end


### PR DESCRIPTION
These matchers are from rspec-expectations but would be useful for testing
rspec-mocks too.

They are only intended for internal usage, so make a good candidate for
extraction.
