### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSpec::Support
+# RSpec::Support [![Inline docs](http://inch-pages.github.io/github/rspec/rspec-support.png)](http://inch-pages.github.io/github/rspec/rspec-support)
 
 `RSpec::Support` provides common functionality to `RSpec::Core`,
 `RSpec::Expectations` and `RSpec::Mocks`. It is considered


### PR DESCRIPTION
I just added the badge @soulcutter requested to the README: ![Inline docs](http://inch-pages.github.io/github/rspec/rspec-support.png)

Your status page for this project is http://inch-pages.github.io/github/rspec/rspec-support

Thanks for giving this a shot!
