### PR TITLE
Improve how we detect module prepend support.

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -21,7 +21,7 @@ module RSpec
       module_function :required_kw_args_supported?
 
       def module_prepends_supported?
-        RUBY_VERSION.to_f >= 2.0
+        Module.private_method_defined?(:prepend)
       end
       module_function :module_prepends_supported?
     end


### PR DESCRIPTION
JRuby 1.7.4+ has experimental ruby 2.0 support,
and reports `RUBY_VERSION` as 2.0 when run with
`JRUBY_OPTS='--2.0'` but does not support module
prepends.

Fixes rspec/rspec-mocks#672.
