### PR TITLE
Fix `with_isolated_stderr` so it does not leak.

### DIFF
--- a/lib/rspec/support/spec/with_isolated_stderr.rb
+++ b/lib/rspec/support/spec/with_isolated_stderr.rb
@@ -6,6 +6,7 @@ module RSpec
         original = $stderr
         $stderr = StringIO.new
         yield
+      ensure
         $stderr = original
       end
 

--- a/spec/rspec/support/spec/with_isolated_std_err_spec.rb
+++ b/spec/rspec/support/spec/with_isolated_std_err_spec.rb
@@ -8,4 +8,14 @@ describe 'isolating a spec from the stderr splitter' do
       $stderr.puts "Imma gonna warn you"
     end
   end
+
+  it 'resets $stderr to its original value even if an error is raised' do
+    orig_stderr = $stderr
+
+    expect {
+      with_isolated_stderr { raise "boom" }
+    }.to raise_error("boom")
+
+    expect($stderr).to be(orig_stderr)
+  end
 end


### PR DESCRIPTION
Without ensure, it leaves $stderr set to a different value.

Fixes rspec/rspec-core#1534.

So that rspec-core issue wasn't actually a problem with rspec-core; it was a problem with this line in an rspec-mocks test:

https://github.com/rspec/rspec-mocks/blob/83c1456d9e9bddcb624b00f636340a837f42e6b2/spec/rspec/mocks/argument_matchers_spec.rb#L209

...which used `with_isolated_stderr`, was wrapping a spot where an exception was raised, and as a result `$stderr` would remain silenced after that.  That in turn cased the exception in the formatter not to be printed to the console like it normally would be.

/cc @JonRowe 
