### PR TITLE
Call #to_s on output to avoid leaking Differ's implementation details.

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -19,7 +19,7 @@ module RSpec
           end
         end
 
-        diff
+        diff.to_s
       end
 
       def diff_as_string(actual, expected)

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -251,6 +251,16 @@ EOD
           expect(diff).to be_empty
         end
 
+        it "returns a String if no diff is returned" do
+          diff = differ.diff 1, 2
+          expect(diff).to be_a(String)
+        end
+
+        it "returns a String if a diff is performed" do
+          diff = differ.diff "a\n", "b\n"
+          expect(diff).to be_a(String)
+        end
+
         context "with :object_preparer option set" do
           let(:differ) do
             RSpec::Support::Differ.new(:object_preparer => lambda { |s| s.to_s.reverse })


### PR DESCRIPTION
Prior to this, the output of `Differ.diff` was an EncodedString if the arguments were diffable. An EncodedString mostly acts like a String, but nothing outside of Differ needs to know it exists.
