### PR TITLE
Don’t create circular ruby gems dependency.

### DIFF
--- a/rspec-support.gemspec
+++ b/rspec-support.gemspec
@@ -31,6 +31,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake",    "~> 10.0.0"
-
-  spec.add_development_dependency "rspec",   ">= 3.0.0.pre"
 end


### PR DESCRIPTION
rspec depends on rspec-(core|mocks|expectations), each
of which depends on this gem...so we shouldn’t depend
on rspec in turn from here.

Our gemfile takes care ensuring we have all of RSpec available
when running the specs.
