### PR TITLE
Differentiate between block args with defaults and without.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### 3.0.1 Development
+[Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.0...3-0-maintenance)
+
+* Fix `BlockSignature` so that it correctly differentiates between
+  required and optional block args. (Myron Marston, rspec-mocks#714)
+
 ### 3.0.0 / 2014-06-01
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.0.rc1...v3.0.0)
 

--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -54,5 +54,26 @@ module RSpec
         end
       end
     end
+
+    if RUBY_PLATFORM == 'java'
+      def self.proc_to_lambda(block)
+        return block if block.lambda?
+        lambda(&block)
+      end
+    elsif respond_to?(:define_singleton_method)
+      def self.proc_to_lambda(block)
+        return block if block.lambda?
+
+        obj = Object.new
+        obj.define_singleton_method(:to_lambda, &block)
+        obj.method(:to_lambda).to_proc
+      end
+    else # 1.8.7
+      def self.proc_to_lambda(block)
+        obj = Object.new
+        (class << obj; self; end).__send__(:define_method, :to_lambda, &block)
+        obj.method(:to_lambda).to_proc
+      end
+    end
   end
 end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -133,11 +133,8 @@ module RSpec
     #
     # @api private
     class BlockSignature < MethodSignature
-      if RubyFeatures.optional_and_splat_args_supported?
-        def classify_parameters
-          super
-          @min_non_kw_args = @max_non_kw_args unless @max_non_kw_args == INFINITY
-        end
+      def initialize(block)
+        super(Support.proc_to_lambda(block))
       end
     end
 

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -3,6 +3,18 @@ require 'rspec/support/method_signature_verifier'
 
 module RSpec
   module Support
+    describe BlockSignature do
+      it 'differentiates optional vs required args', :if => RubyFeatures.optional_and_splat_args_supported? do
+        bs = BlockSignature.new(Proc.new { |a, b| })
+        expect(bs.min_non_kw_args).to eq(2)
+        expect(bs.max_non_kw_args).to eq(2)
+
+        bs = eval("BlockSignature.new(Proc.new { |a, b=2| })")
+        expect(bs.min_non_kw_args).to eq(1)
+        expect(bs.max_non_kw_args).to eq(2)
+      end
+    end
+
     describe MethodSignatureVerifier do
       describe '#verify!' do
         let(:signature) { MethodSignature.new(test_method) }

--- a/spec/rspec/support_spec.rb
+++ b/spec/rspec/support_spec.rb
@@ -75,5 +75,20 @@ module RSpec
         end
       end
     end
+
+    describe ".proc_to_lambda", :if => Proc.method_defined?(:lambda?) do
+      it "converts a proc to a lambda" do
+        p = Proc.new { 47 }
+        expect(p).not_to be_lambda
+        l = Support.proc_to_lambda(p)
+        expect(l).to be_lambda
+        expect(l.call).to eq(47)
+      end
+
+      it 'returns a lambda unchanged' do
+        l = lambda { }
+        expect(Support.proc_to_lambda(l)).to be(l)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes rspec/rspec-mocks#714.
