### PR TITLE
Remove `proc_to_lambda`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### 3.0.2 Development
+[Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.1...3-0-maintenance)
+
+* Revert `BlockSignature` change from 3.0.1 because of a ruby bug that
+  caused it to change the block's behavior (https://bugs.ruby-lang.org/issues/9967).
+  (Myron Marston, rspec-mocks#721)
+
 ### 3.0.1 / 2014-06-19
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.0...v3.0.1)
 

--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -54,32 +54,5 @@ module RSpec
         end
       end
     end
-
-    if RUBY_PLATFORM == 'java'
-      if Proc.method_defined?(:lambda?)
-        def self.proc_to_lambda(block)
-          return block if block.lambda?
-          lambda(&block)
-        end
-      else
-        def self.proc_to_lambda(block)
-          lambda(&block)
-        end
-      end
-    elsif respond_to?(:define_singleton_method)
-      def self.proc_to_lambda(block)
-        return block if block.lambda?
-
-        obj = Object.new
-        obj.define_singleton_method(:to_lambda, &block)
-        obj.method(:to_lambda).to_proc
-      end
-    else # 1.8.7
-      def self.proc_to_lambda(block)
-        obj = Object.new
-        (class << obj; self; end).__send__(:define_method, :to_lambda, &block)
-        obj.method(:to_lambda).to_proc
-      end
-    end
   end
 end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -133,8 +133,11 @@ module RSpec
     #
     # @api private
     class BlockSignature < MethodSignature
-      def initialize(block)
-        super(Support.proc_to_lambda(block))
+      if RubyFeatures.optional_and_splat_args_supported?
+        def classify_parameters
+          super
+          @min_non_kw_args = @max_non_kw_args unless @max_non_kw_args == INFINITY
+        end
       end
     end
 

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -3,18 +3,6 @@ require 'rspec/support/method_signature_verifier'
 
 module RSpec
   module Support
-    describe BlockSignature do
-      it 'differentiates optional vs required args', :if => RubyFeatures.optional_and_splat_args_supported? do
-        bs = BlockSignature.new(Proc.new { |a, b| })
-        expect(bs.min_non_kw_args).to eq(2)
-        expect(bs.max_non_kw_args).to eq(2)
-
-        bs = eval("BlockSignature.new(Proc.new { |a, b=2| })")
-        expect(bs.min_non_kw_args).to eq(1)
-        expect(bs.max_non_kw_args).to eq(2)
-      end
-    end
-
     describe MethodSignatureVerifier do
       describe '#verify!' do
         let(:signature) { MethodSignature.new(test_method) }

--- a/spec/rspec/support_spec.rb
+++ b/spec/rspec/support_spec.rb
@@ -75,30 +75,5 @@ module RSpec
         end
       end
     end
-
-    describe ".proc_to_lambda" do
-      context "on an interpreter that provides Proc#lambda?", :if => Proc.method_defined?(:lambda?) do
-        it "converts a proc to a lambda" do
-          p = Proc.new { 47 }
-          expect(p).not_to be_lambda
-          l = Support.proc_to_lambda(p)
-          expect(l).to be_lambda
-          expect(l.call).to eq(47)
-        end
-
-        it 'returns a lambda unchanged' do
-          l = lambda { }
-          expect(Support.proc_to_lambda(l)).to be(l)
-        end
-      end
-
-      context "on an interpreter that does not provide Proc#lambda?", :unless => Proc.method_defined?(:lambda?) do
-        it 'converts a proc to a lambda' do
-          p = Proc.new { return 47 }
-          l = Support.proc_to_lambda(p)
-          expect(l.call).to eq(47)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
There's a very odd ruby bug that makes this unsafe to use, as its
usage mutates the behavior of the block:

https://bugs.ruby-lang.org/issues/9967

Unfortunately, this un-fixes rspec/rspec-mocks#714, but we've got to do it.
