### PR TITLE
Generalize the gem backtrace exclusion.

### DIFF
--- a/lib/rspec/support/spec/stderr_splitter.rb
+++ b/lib/rspec/support/spec/stderr_splitter.rb
@@ -25,7 +25,7 @@ module RSpec
       # To work around JRuby error:
       # TypeError: $stderr must have write method, RSpec::StdErrSplitter given
       def write(line)
-        if line !~ /^\S+gems\/ruby\-\S+:\d+: warning:/
+        if line !~ %r{^\S+/gems/\S+:\d+: warning:} # http://rubular.com/r/kqeUIZOfPG
           @orig_stderr.write(line)
           @output_tracker.write(line)
         end


### PR DESCRIPTION
Previous regex matcher let gems slip through if a custom path was
provided to bundler (e.g. `bundle install --path ../bundle`). Remove any
explicit path dependencies on potential ruby version based directory
names.
