### PR TITLE
Ruby 2.1 Module#prepend isn't private

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Bug Fixes:
 * Fix regression in `Support#method_handle_for` where proxy objects
   with method delegated would wrongly not return a method handle.
   (Jon Rowe, #90)
+* Fix detection of Module#prepend support in Ruby 2.1+ where it is public
 
 ### 3.0.2 / 2014-06-20
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.1...v3.0.2)

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -21,7 +21,7 @@ module RSpec
       module_function :required_kw_args_supported?
 
       def module_prepends_supported?
-        Module.private_method_defined?(:prepend)
+        Module.method_defined?(:prepend) || Module.private_method_defined?(:prepend)
       end
       module_function :module_prepends_supported?
 


### PR DESCRIPTION
Ruby 2.0.0:

```
>> Module.private_method_defined?(:prepend)
=> true
>> Module.method_defined?(:prepend)
=> false
```

Ruby 2.1.1:

```
>> Module.private_method_defined?(:prepend)
=> false
>> Module.method_defined?(:prepend)
=> true
```

This causes [this check](https://github.com/rspec/rspec-support/blob/master/lib/rspec/support/ruby_features.rb#L24) to fail on Ruby 2.1.
