### PR TITLE
Fix rspec/support/warnings so it can be loaded and used in isolation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Bug Fixes:
   with method delegated would wrongly not return a method handle.
   (Jon Rowe, #90)
 * Properly detect Module#prepend support in Ruby 2.1+ (Ben Langfeld, #91)
+* Fix `rspec/support/warnings.rb` so it can be loaded and used in
+  isolation. (Myron Marston, #93)
 
 ### 3.0.2 / 2014-06-20
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.1...v3.0.2)

--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -1,3 +1,6 @@
+require 'rspec/support'
+RSpec::Support.require_rspec_support "caller_filter"
+
 module RSpec
   module Support
     module Warnings

--- a/spec/rspec/support/warnings_spec.rb
+++ b/spec/rspec/support/warnings_spec.rb
@@ -1,9 +1,17 @@
 require "spec_helper"
 require "rspec/support/warnings"
+require 'shellwords'
 
 describe "rspec warnings and deprecations" do
   let(:warning_object) do
     Object.new.tap { |o| o.extend(RSpec::Support::Warnings) }
+  end
+
+  it 'works when required in isolation' do
+    lib_dir = Shellwords.escape(File.expand_path("../../../../lib", __FILE__))
+    output = `ruby -I#{lib_dir} -rrspec/support/warnings -e "RSpec.deprecate('foo')" 2>&1`
+    expect(output).to start_with("DEPRECATION: foo is deprecated")
+    expect($?.exitstatus).to eq(0)
   end
 
   context "when rspec-core is not available" do


### PR DESCRIPTION
It relies upon CallerFilter but wasn't requiring it.
