### PR TITLE
Do not silence `ArgumentError` from `==`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### 3.1.0 Development
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.3...master)
 
+Bug Fixes:
+
+* Fix `FuzzyMatcher` so that it does not silence `ArgumentError` raised
+  from broken implementations of `==`. (Myron Marston, #94)
+
 ### 3.0.3 / 2014-07-21
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.0.2...v3.0.3)
 

--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -10,10 +10,12 @@ module RSpec
           return arrays_match?(expected, actual.to_a)
         elsif Hash === expected && Hash === actual
           return hashes_match?(expected, actual)
+        elsif actual == expected
+          return true
         end
 
         begin
-          actual == expected || expected === actual
+          expected === actual
         rescue ArgumentError
           # Some objects, like 0-arg lambdas on 1.9+, raise
           # ArgumentError for `expected === actual`.

--- a/spec/rspec/support/fuzzy_matcher_spec.rb
+++ b/spec/rspec/support/fuzzy_matcher_spec.rb
@@ -56,6 +56,24 @@ module RSpec
         end
       end
 
+      context "when given an object whose implementation of `==` raises an ArgumentError" do
+        it 'surfaces the error' do
+          klass = Class.new do
+            attr_accessor :foo
+            def ==(other)
+              other.foo == foo
+            end
+          end
+          instance = klass.new
+
+          other = Object.new
+          def other.foo(arg); end
+
+          expect { instance == other }.to raise_error(ArgumentError)
+          expect { FuzzyMatcher.values_match?(other, instance) }.to raise_error(ArgumentError)
+        end
+      end
+
       context "when given two arrays" do
         it 'returns true if they have equal values' do
           expect([1, 2.0]).to match_against([1.0, 2])


### PR DESCRIPTION
In troubleshooting rspec/rspec-expectations#610, I noticed this problem.
