### PR TITLE
use correct alt seperator

### DIFF
--- a/lib/rspec/support/os.rb
+++ b/lib/rspec/support/os.rb
@@ -10,7 +10,7 @@ module RSpec
       module_function :windows?
 
       def windows_file_path?
-        ::File::ALT_SEPARATOR == ":"
+        ::File::ALT_SEPARATOR == '\\'
       end
       module_function :windows_file_path?
     end

--- a/spec/rspec/support/os_spec.rb
+++ b/spec/rspec/support/os_spec.rb
@@ -22,7 +22,7 @@ module RSpec
 
       describe ".windows_file_path?" do
         it "returns true when the file alt seperator is a colon" do
-          stub_const("File::ALT_SEPARATOR", ":") unless OS.windows?
+          stub_const("File::ALT_SEPARATOR", "\\") unless OS.windows?
           expect(OS).to be_windows_file_path
         end
 


### PR DESCRIPTION
As pointed out by @bryonb07 and verified at  [https://github.com/ruby/ruby/blob/trunk/file.c#L2864](https://github.com/ruby/ruby/blob/ab5517a06c407721520000060fce95d905b8d219/file.c#L2864)
