### PR TITLE
Optimize `RSpec::CallerFilter`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 bin
 bundle
+
+Gemfile-custom

--- a/benchmarks/caller_vs_caller_locations.rb
+++ b/benchmarks/caller_vs_caller_locations.rb
@@ -1,0 +1,19 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.report("caller()              ") { caller }
+  x.report("caller_locations()    ") { caller_locations }
+  x.report("caller(1, 2)          ") { caller(1, 2) }
+  x.report("caller_locations(1, 2)") { caller_locations(1, 2) }
+end
+
+__END__
+
+caller()
+                        118.586k (±17.7%) i/s -    573.893k
+caller_locations()
+                        355.988k (±17.8%) i/s -      1.709M
+caller(1, 2)
+                        336.841k (±18.6%) i/s -      1.615M
+caller_locations(1, 2)
+                        781.330k (±23.5%) i/s -      3.665M

--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -38,19 +38,17 @@ module RSpec
         # performance on the common case of creating a double.
         increment = 5
         i         = 1
-        line      = nil
 
-        until line
-          stack = caller(i, increment)
+        loop do
+          stack = caller_locations(i, increment)
           raise "No non-lib lines in stack" unless stack
 
-          line = stack.find { |l| l !~ IGNORE_REGEX }
+          line = stack.find { |l| l.path !~ IGNORE_REGEX }
+          return line.to_s if line
 
           i         += increment
           increment *= 2 # The choice of two here is arbitrary.
         end
-
-        line
       end
     else
       # Earlier rubies do not support the two argument form of `caller`. This


### PR DESCRIPTION
- Use `caller_locations` rather than `caller`. It's apparently
  much faster. I suspect that it's due to the fact that `caller`
  has to due some extra calculation for each stack frame in order
  to combine them into a full line description string, where as
  `caller_locations` returns an object with the separate stack
  frame attributes and does the full line description calculation
  when you call `to_s`.
- Immediately return when we have the line, rather than updating `i`
  and `increment` for now reason.

/cc @xaviershay 
