### PR TITLE
This spec has been intermittently failing on ruby 2.2 due to `birthtime`

### DIFF
--- a/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -22,6 +22,9 @@ describe 'RSpec::Support::StdErrSplitter' do
   it 'conforms to the stderr interface' do
     stderr_methods = stderr.methods
 
+    # On 2.2, there's a weird issue where stderr sometimes responds to `birthtime` and sometimes doesn't...
+    stderr_methods -= [:birthtime] if RUBY_VERSION =~ /^2\.2/
+
     # No idea why, but on our AppVeyor windows builds it doesn't respond to these...
     stderr_methods -= [:close_on_exec?, :close_on_exec=] if RSpec::Support::OS.windows?
 


### PR DESCRIPTION
Locally I can’t repro, unfortunately :(.