### PR TITLE
Another attempt at travis bundler caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
-# This file was generated on 2014-12-31T23:38:57-08:00 from the rspec-dev repo.
+# This file was generated on 2014-12-29T15:16:37-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 language: ruby
 sudo: false
 cache:
   directories:
-    - ../rspec-core/bundle
-    - ../rspec-expectations/bundle
-    - ../rspec-mocks/bundle
-    - ../rspec-rails/bundle
-    - ../rspec-support/bundle
+    - ../bundle
 before_install:
   - "script/clone_all_rspec_repos"
   # Downgrade bundler to work around https://github.com/bundler/bundler/issues/3004
   # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it
   - if [ -z "$JRUBY_OPTS" ]; then gem install bundler -v=1.5.3 && alias bundle="bundle _1.5.3_"; fi
-bundler_args: "--binstubs --standalone --without documentation --path bundle"
+bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 script: "script/run_build"
 rvm:
   - 1.8.7

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2014-12-31T23:38:57-08:00 from the rspec-dev repo.
+# This file was generated on 2014-12-29T15:16:37-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -11,15 +11,8 @@ SPECS_HAVE_RUN_FILE=specs.out
 MAINTENANCE_BRANCH=`cat maintenance-branch`
 
 function clone_repo {
-  if [ ! -e $1/Gemfile ]; then # don't reclone
-    # deal with our bundler cache directory.
-    # Git won't clone into a non-empty dir so we have to move it aside and move it back.
-    mkdir -p $1/bundle
-    pushd $1
-    mv bundle ../$1-bundle
-    travis_retry eval "git clone git://github.com/rspec/$1 --depth 1 --branch $MAINTENANCE_BRANCH ."
-    mv ../$1-bundle bundle
-    popd
+  if [ ! -d $1 ]; then # don't clone if the dir is already there
+    travis_retry eval "git clone git://github.com/rspec/$1 --depth 1 --branch $MAINTENANCE_BRANCH"
   fi;
 }
 
@@ -55,7 +48,7 @@ function run_cukes {
     else
       # Prepare RUBYOPT for scenarios that are shelling out to ruby,
       # and PATH for those that are using `rspec` or `rake`.
-      RUBYOPT="-I${PWD}/bundle -rbundler/setup" \
+      RUBYOPT="-I${PWD}/../bundle -rbundler/setup" \
          PATH="${PWD}/bin:$PATH" \
          bin/cucumber --strict
     fi
@@ -75,10 +68,14 @@ function run_spec_suite_for {
     echo "Running specs for $1"
     pushd ../$1
     unset BUNDLE_GEMFILE
-    bundle_install_flags=`cat .travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
+    if [ $1 == "rspec-rails" ]; then
+      bundle_install_flags=`cat .travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
+    else
+      # The other repos install bundle into `./bundle` but we are testing using `../bundle`
+      bundle_install_flags="--binstubs --standalone --without documentation --path ../bundle"
+    fi
     travis_retry eval "bundle install $bundle_install_flags"
     run_specs_and_record_done
-    bundle clean # prep for travis caching
     popd
   fi;
 }


### PR DESCRIPTION
For rspec/rspec-dev#101. The changes in #102 don’t seem
to be caching properly. I’m switching back to a single
shared bundle directory but manually caching it rather
than using `cache: bundler` so that `bundle clean` doesn’t
run.

I plan to put this in rspec-dev (and all repos) if it works
but wanted to test on just one repo for now.