### PR TITLE
Don’t consider empty arrays and empty hashes to match.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ Enhancements:
 
 * Add extra Ruby type detection. (Jon Rowe, #133)
 
+Bug Fixes:
+
+* Do not consider `[]` and `{}` to match when performing fuzzy matching.
+  (Myron Marston, #157)
+
 ### 3.1.2 / 2014-10-08
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.1.1...v3.1.2)
 

--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -6,13 +6,13 @@ module RSpec
     module FuzzyMatcher
       # @api private
       def self.values_match?(expected, actual)
-        if Array === expected && Enumerable === actual && !(Struct === actual)
+        if Hash === actual
+          return hashes_match?(expected, actual) if Hash === expected
+        elsif Array === expected && Enumerable === actual && !(Struct === actual)
           return arrays_match?(expected, actual.to_a)
-        elsif Hash === expected && Hash === actual
-          return hashes_match?(expected, actual)
-        elsif actual == expected
-          return true
         end
+
+        return true if actual == expected
 
         begin
           expected === actual

--- a/spec/rspec/support/fuzzy_matcher_spec.rb
+++ b/spec/rspec/support/fuzzy_matcher_spec.rb
@@ -127,6 +127,11 @@ module RSpec
         expect([String, Fixnum]).not_to match_against(my_enum)
       end
 
+      it 'does not match an empty hash against an empty array or vice-versa' do
+        expect({}).not_to match_against([])
+        expect([]).not_to match_against({})
+      end
+
       context 'when given two hashes' do
         it 'returns true when their keys and values are equal' do
           expect(:a => 5, :b => 2.0).to match_against(:a => 5.0, :b => 2)


### PR DESCRIPTION
Fixes #156.