### PR TITLE
Allow differ instance to be used multiple times

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -25,12 +25,13 @@ module RSpec
 
       # rubocop:disable MethodLength
       def diff_as_string(actual, expected)
-        @encoding = pick_encoding actual, expected
+        encoding = pick_encoding(actual, expected)
 
-        @actual   = EncodedString.new(actual, @encoding)
-        @expected = EncodedString.new(expected, @encoding)
+        actual   = EncodedString.new(actual, encoding)
+        expected = EncodedString.new(expected, encoding)
 
-        output = EncodedString.new("\n", @encoding)
+        output = EncodedString.new("\n", encoding)
+        hunks = build_hunks(actual, expected)
 
         hunks.each_cons(2) do |prev_hunk, current_hunk|
           begin
@@ -48,7 +49,7 @@ module RSpec
 
         color_diff output
       rescue Encoding::CompatibilityError
-        handle_encoding_errors
+        handle_encoding_errors(actual, expected)
       end
       # rubocop:enable MethodLength
 
@@ -109,8 +110,8 @@ module RSpec
         end
       end
 
-      def hunks
-        @hunks ||= HunkGenerator.new(@actual, @expected).hunks
+      def build_hunks(actual, expected)
+        HunkGenerator.new(actual, expected).hunks
       end
 
       def finalize_output(output, final_line)
@@ -198,14 +199,14 @@ module RSpec
         end
       end
 
-      def handle_encoding_errors
-        if @actual.source_encoding != @expected.source_encoding
+      def handle_encoding_errors(actual, expected)
+        if actual.source_encoding != expected.source_encoding
           "Could not produce a diff because the encoding of the actual string " \
-          "(#{@actual.source_encoding}) differs from the encoding of the expected " \
-          "string (#{@expected.source_encoding})"
+          "(#{actual.source_encoding}) differs from the encoding of the expected " \
+          "string (#{expected.source_encoding})"
         else
           "Could not produce a diff because of the encoding of the string " \
-          "(#{@expected.source_encoding})"
+          "(#{expected.source_encoding})"
         end
       end
     end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -37,6 +37,37 @@ EOD
           expect(diff).to eql(expected_diff)
         end
 
+        it "outputs unified diff of two strings when used multiple times" do
+          expected = "foo\nzap\nbar\nthis\nis\nsoo\nvery\nvery\nequal\ninsert\na\nanother\nline\n"
+          actual   = "foo\nbar\nzap\nthis\nis\nsoo\nvery\nvery\nequal\ninsert\na\nline\n"
+
+          expected_diff = dedent(<<-'EOS')
+            |
+            |
+            |@@ -1,6 +1,6 @@
+            | foo
+            |-zap
+            | bar
+            |+zap
+            | this
+            | is
+            | soo
+            |@@ -9,6 +9,5 @@
+            | equal
+            | insert
+            | a
+            |-another
+            | line
+            |
+          EOS
+
+          diff = differ.diff(actual, expected)
+          expect(diff).to eql(expected_diff)
+
+          diff = differ.diff(actual, expected)
+          expect(diff).to eql(expected_diff)
+        end
+
         if String.method_defined?(:encoding)
           it "returns an empty string if strings are not multiline" do
             expected = "Tu avec carte {count} item has".encode('UTF-16LE')


### PR DESCRIPTION
related to this conversation: https://github.com/rspec/rspec-expectations/pull/713#discussion_r23645315

Story short: current implementation of `Differ` relies on `@hunks` to output diffs, it uses method `hunks` that has memoizing inside `@hunks ||= ...`, which means when `Differ` instance used subsequently it will use `@hunks` from the first run. Since `Differ` has only one method you usually call it with (ie `#diff`) I have put an `@hunks = nil` there, so it will instantiate new `@hunks` each time.

I have considered creating additional class which will be instantiated in each run of `#diff`and basically all calculation will be delegated to it. This could make this a bit clearer, but on the other hand a bit slower. WDYT?

/c @rspec/rspec @myronmarston 