### PR TITLE
Update the default `skip_frames` value.

### DIFF
--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -42,7 +42,13 @@ module RSpec
       # such a way that would return the wrong stack frame, a test will fail to tell you.
       #
       # See benchmarks/skip_frames_for_caller_filter.rb for measurements.
-      def self.first_non_rspec_line(skip_frames=1, increment=5)
+      def self.first_non_rspec_line(skip_frames=3, increment=5)
+        # Why a default `skip_frames` of 3?
+        # By the time `caller_locations` is called below, the first 3 frames are:
+        #   lib/rspec/support/caller_filter.rb:63:in `block in first_non_rspec_line'
+        #   lib/rspec/support/caller_filter.rb:62:in `loop'
+        #   lib/rspec/support/caller_filter.rb:62:in `first_non_rspec_line'
+
         # `caller` is an expensive method that scales linearly with the size of
         # the stack. The performance hit for fetching it in chunks is small,
         # and since the target line is probably near the top of the stack, the

--- a/spec/rspec/support/caller_filter_spec.rb
+++ b/spec/rspec/support/caller_filter_spec.rb
@@ -4,17 +4,25 @@ require 'rspec/support/caller_filter'
 
 module RSpec
   describe CallerFilter do
-    def ruby_files_in_lib(lib)
-      # http://rubular.com/r/HYpUMftlG2
-      path = $LOAD_PATH.find { |p| p.match(/\/rspec-#{lib}(-[a-f0-9]+)?\/lib/) }
+    it 'can receive skip_frames and increment arguments' do
+      expect(RSpec::CallerFilter.first_non_rspec_line(1, 5)).to include("#{__FILE__}:#{__LINE__}")
+    end
 
-      Dir["#{path}/**/*.rb"].sort.tap do |files|
-        # Just a sanity check...
-        expect(files.count).to be > 5
-      end
+    it 'returns the immediate caller when called from a spec' do
+      expect(RSpec::CallerFilter.first_non_rspec_line).to include("#{__FILE__}:#{__LINE__}")
     end
 
     describe "the filtering regex" do
+      def ruby_files_in_lib(lib)
+        # http://rubular.com/r/HYpUMftlG2
+        path = $LOAD_PATH.find { |p| p.match(/\/rspec-#{lib}(-[a-f0-9]+)?\/lib/) }
+
+        Dir["#{path}/**/*.rb"].sort.tap do |files|
+          # Just a sanity check...
+          expect(files.count).to be > 5
+        end
+      end
+
       def unmatched_from(files)
         files.reject { |file| file.match(CallerFilter::IGNORE_REGEX) }
       end
@@ -60,10 +68,6 @@ module RSpec
             require "rspec/support/test_dir/file"
           }.to change { $_caller_filter }.to(include "#{__FILE__}:#{__LINE__ - 1}")
         end
-      end
-
-      it 'can receive skip_frames and increment arguments' do
-        expect(RSpec::CallerFilter.first_non_rspec_line(1, 5)).to include("#{__FILE__}:#{__LINE__}")
       end
     end
   end


### PR DESCRIPTION
There are 2 more frames we can safely skip. Skipping
these by default increases the chance we’ll hit the first
non-rspec line in the first group of frames, which will
perform better.