### PR TITLE
Fix regression on rbx 2.2.

### DIFF
--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support "ruby_features"
+
 module RSpec
   # Consistent implementation for "cleaning" the caller method to strip out
   # non-rspec lines. This enables errors to be reported at the call site in
@@ -25,7 +27,7 @@ module RSpec
     # with this complexity in our `RSpec.deprecate` calls, so we ignore it here.
     IGNORE_REGEX = Regexp.union(LIB_REGEX, "rubygems/core_ext/kernel_require.rb")
 
-    if RUBY_VERSION >= '2.0.0'
+    if RSpec::Support::RubyFeatures.caller_locations_supported?
       # This supports args because it's more efficient when the caller specifies
       # these. It allows us to skip frames the caller knows are part of RSpec,
       # and to decrease the increment size if the caller is confident the line will

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -49,6 +49,10 @@ module RSpec
         Method.method_defined?(:parameters)
       end
 
+      def caller_locations_supported?
+        respond_to?(:caller_locations, true)
+      end
+
       if Ruby.mri?
         def kw_args_supported?
           RUBY_VERSION >= '2.0.0'

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -70,6 +70,13 @@ module RSpec
       specify "#supports_rebinding_module_methods? exists" do
         RubyFeatures.supports_rebinding_module_methods?
       end
+
+      specify "#caller_locations_supported? exists" do
+        RubyFeatures.caller_locations_supported?
+        if Ruby.mri?
+          expect(RubyFeatures.caller_locations_supported?).to eq(RUBY_VERSION >= '2.0.0')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Apparently, it doesn’t define `caller_locations` even
thought it claims to be `RUBY_VERSION >= ‘2.0.0’`.

Fixes rspec/rspec-core#1863.