### PR TITLE
The Differ no longer catches CompatibilityErrors

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -48,8 +48,6 @@ module RSpec
         finalize_output(output, hunks.last.diff(format_type).to_s) if hunks.last
 
         color_diff output
-      rescue Encoding::CompatibilityError
-        handle_encoding_errors(actual, expected)
       end
       # rubocop:enable MethodLength
 
@@ -187,17 +185,6 @@ module RSpec
           object =~ /\n/ ? object : object.inspect
         else
           PP.pp(object, "")
-        end
-      end
-
-      def handle_encoding_errors(actual, expected)
-        if actual.source_encoding != expected.source_encoding
-          "Could not produce a diff because the encoding of the actual string " \
-          "(#{actual.source_encoding}) differs from the encoding of the expected " \
-          "string (#{expected.source_encoding})"
-        else
-          "Could not produce a diff because of the encoding of the string " \
-          "(#{expected.source_encoding})"
         end
       end
     end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -112,17 +112,6 @@ EOD
             expect(differ.diff(actual, expected)).to eq("\n@@ -1,2 +1,2 @@\n-Tu avec carte {count} item has\n+Tu avec carté {count} itém has\n")
             expect(differ.diff(actual, expected).encoding).to eq(Encoding.default_external)
           end
-
-          it 'handles any encoding error that occurs with a helpful error message' do
-            expect(RSpec::Support::HunkGenerator).to receive(:new).
-              and_raise(Encoding::CompatibilityError)
-            expected = "Tu avec carte {count} item has\n".encode('us-ascii')
-            actual   = "Tu avec carté {count} itém has\n"
-            diff = differ.diff(actual, expected)
-            expect(diff).to match(/Could not produce a diff/)
-            expect(diff).to match(/actual string \(UTF-8\)/)
-            expect(diff).to match(/expected string \(US-ASCII\)/)
-          end
         end
 
         it "outputs unified diff message of two objects" do


### PR DESCRIPTION
This code was introduced in 
https://github.com/rspec/rspec-expectations/pull/220/files#diff-9533f5f156a38a3307ecfc610d2282d7R47

but is no longer raised either by the the current test code, the original test
code
 @expected="Tu avec carté {count} itém has".encode('UTF-16LE')
 @actual="Tu avec carte {count} item has".encode('UTF-16LE') or any other
variations I've tried.

So, I'm proposing to remove it, especially since encoding
is well-supported and tested by EncodedString, which the Differ relies on.