### PR TITLE
Unify be_identical_string/be_diffed_as in spec/string_matcher.rb

### DIFF
--- a/lib/rspec/support/spec/string_matcher.rb
+++ b/lib/rspec/support/spec/string_matcher.rb
@@ -1,0 +1,46 @@
+require 'rspec/matchers'
+# Special matcher for comparing encoded strings so that
+# we don't run any expectation failures through the Differ,
+# which also relies on EncodedString. Instead, confirm the
+# strings have the same bytes.
+RSpec::Matchers.define :be_identical_string do |expected|
+
+  if String.method_defined?(:encoding)
+    match do
+      expected_encoding? &&
+        actual.bytes.to_a == expected.bytes.to_a
+    end
+
+    failure_message do
+      "expected\n#{actual.inspect} (#{actual.encoding.name}) to be identical to\n"\
+        "#{expected.inspect} (#{expected.encoding.name})\n"\
+        "The exact bytes are printed below for more detail:\n"\
+        "#{actual.bytes.to_a}\n"\
+        "#{expected.bytes.to_a}\n"\
+    end
+
+    # Depends on chaining :with_same_encoding for it to
+    # check for string encoding.
+    def expected_encoding?
+      if defined?(@expect_same_encoding) && @expect_same_encoding
+        actual.encoding == expected.encoding
+      else
+        true
+      end
+    end
+  else
+    match do
+      actual.split(//) == expected.split(//)
+    end
+
+    failure_message do
+      "expected\n#{actual.inspect} to be identical to\n#{expected.inspect}\n"
+    end
+  end
+
+  chain :with_same_encoding do
+    @expect_same_encoding ||= true
+  end
+end
+RSpec::Matchers.alias_matcher :a_string_identical_to, :be_identical_string
+RSpec::Matchers.alias_matcher :be_diffed_as, :be_identical_string

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -3,33 +3,8 @@ require 'spec_helper'
 require 'ostruct'
 require 'timeout'
 require 'rspec/support/differ'
+require 'rspec/support/spec/string_matcher'
 
-# Special matcher for comparing strings so that
-# we don't run any expectation failures through the Differ.
-# Instead, confirm the strings have the same bytes.
-RSpec::Matchers.define :be_diffed_as do |expected|
-
-  if String.method_defined?(:encoding)
-    match do
-      actual.bytes.to_a == expected.bytes.to_a
-    end
-
-    failure_message do
-      "expected\n#{actual.inspect} to be identical to\n#{expected.inspect}\n"\
-        "The exact bytes are printed below for more detail:\n"\
-        "#{actual.bytes.to_a}\n"\
-        "#{expected.bytes.to_a}\n"\
-    end
-  else
-    match do
-      actual.split(//) == expected.split(//)
-    end
-
-    failure_message do
-      "expected\n#{actual.inspect} to be identical to\n#{expected.inspect}\n"
-    end
-  end
-end
 module RSpec
   module Support
     describe Differ do


### PR DESCRIPTION
Changed meaning of be_identical_string not to include an encoding comparison. 
Encoding comparison is now only turned on by chaining
'with_same_encoding'.

This leaves open the possibility of chaining 'with_encoding(enc)', but there's
currently not need for that.