### PR TITLE
Add `in_sub_process_where_possible`

### DIFF
--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -35,13 +35,18 @@ module RSpec
 
           raise exception if exception
         end
+        # rubocop:enable MethodLength
+        alias :in_sub_process_if_possible :in_sub_process
       else
         def in_sub_process(*)
           skip "This spec requires forking to work properly, " \
                "and your platform does not support forking"
         end
+
+        def in_sub_process_if_possible(*)
+          yield
+        end
       end
-      # rubocop:enable MethodLength
     end
   end
 end


### PR DESCRIPTION
For specs where we care about not poisoning our environment it'd be good to run
them in a subprocess, but these specs may be too important to skip on
platforms without fork, so we can just run normally instead.