### PR TITLE
Move equality output formatting code out of rspec-expectations

### DIFF
--- a/lib/rspec/support/object_inspector.rb
+++ b/lib/rspec/support/object_inspector.rb
@@ -1,0 +1,48 @@
+module RSpec
+  module Support
+    # Provide additional output details beyond what `inspect` provides when
+    # printing Time, DateTime, or BigDecimal
+    module ObjectInspector
+      # @api private
+      def self.inspect(object)
+        if Time === object
+          format_time(object)
+        elsif defined?(DateTime) && DateTime === object
+          format_date_time(object)
+        elsif defined?(BigDecimal) && BigDecimal === object
+          "#{object.to_s 'F'} (#{object.inspect})"
+        elsif RSpec::Support.is_a_matcher?(object) && object.respond_to?(:description)
+          object.description
+        else
+          object.inspect
+        end
+      end
+
+      TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+      if Time.method_defined?(:nsec)
+        # @private
+        def self.format_time(time)
+          time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
+        end
+      else # for 1.8.7
+        # @private
+        def self.format_time(time)
+          time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
+        end
+      end
+
+      DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
+      # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
+      # defined use a custom format string that includes more time precision.
+      # @private
+      def self.format_date_time(date_time)
+        if defined?(ActiveSupport)
+          date_time.strftime(DATE_TIME_FORMAT)
+        else
+          date_time.inspect
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -1,4 +1,6 @@
 require 'rspec/support'
+require 'rspec/support/spec/in_sub_process'
+
 RSpec::Support.require_rspec_support "spec/deprecation_helpers"
 RSpec::Support.require_rspec_support "spec/with_isolated_stderr"
 RSpec::Support.require_rspec_support "spec/stderr_splitter"
@@ -12,6 +14,7 @@ RSpec.configure do |c|
   c.include RSpecHelpers
   c.include RSpec::Support::WithIsolatedStdErr
   c.include RSpec::Support::FormattingSupport
+  c.include RSpec::Support::InSubProcess
 
   unless defined?(Debugger) # debugger causes warnings when used
     c.before do

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -1,0 +1,97 @@
+require 'rspec/support/object_inspector'
+require 'rspec/matchers/fail_matchers'
+
+module RSpec
+  module Support
+    describe ObjectInspector, ".inspect" do
+      context 'with Time objects' do
+        let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
+        let(:formatted_time) { ObjectInspector.inspect(time) }
+
+        it 'produces an extended output' do
+          expected_output = "1969-12-31 19:01:40.000101"
+          expect(formatted_time).to include(expected_output)
+        end
+      end
+
+      context 'with DateTime objects' do
+        def with_date_loaded
+          in_sub_process_if_possible do
+            require 'date'
+            yield
+          end
+        end
+
+        let(:date_time) { DateTime.new(2000, 1, 1, 1, 1, Rational(1, 10)) }
+        let(:formatted_date_time) { ObjectInspector.inspect(date_time) }
+
+        it 'formats the DateTime using inspect' do
+          with_date_loaded do
+            expect(formatted_date_time).to eq(date_time.inspect)
+          end
+        end
+
+        it 'does not require DateTime to be defined since you need to require `date` to make it available' do
+          hide_const('DateTime')
+          expect(ObjectInspector.inspect('Test String')).to eq('"Test String"')
+        end
+
+        context 'when ActiveSupport is loaded' do
+          it "uses a custom format to ensure the output is different when DateTimes differ" do
+            stub_const("ActiveSupport", Module.new)
+
+            with_date_loaded do
+              expected_date_time = 'Sat, 01 Jan 2000 01:01:00.100000000 +0000'
+              expect(formatted_date_time).to eq(expected_date_time)
+            end
+          end
+        end
+      end
+
+      context 'with BigDecimal objects' do
+        let(:float)   { 3.3 }
+        let(:decimal) { BigDecimal("3.3") }
+
+        let(:formatted_decimal) { ObjectInspector.inspect(decimal) }
+
+        it 'fails with a conventional representation of the decimal' do
+          in_sub_process_if_possible do
+            require 'bigdecimal'
+            expect(formatted_decimal).to include('3.3 (#<BigDecimal')
+          end
+        end
+
+        it 'does not require BigDecimal to be defined since you need to require `bigdecimal` to make it available' do
+          hide_const('BigDecimal')
+          expect(ObjectInspector.inspect('Test String')).to eq('"Test String"')
+        end
+      end
+
+      context 'with objects that implement description' do
+        RSpec::Matchers.define :matcher_with_description do
+          match { true }
+          description { :description }
+        end
+
+        RSpec::Matchers.define :matcher_without_a_description do
+          match { true }
+          undef description
+        end
+
+        it "produces a description when a matcher object has a description" do
+          expect(ObjectInspector.inspect(matcher_with_description)).to eq(:description)
+        end
+
+        it "does not produce a description unless the object is a matcher" do
+          double = double('non-matcher double', :description => true)
+          expect(ObjectInspector.inspect(double)).to eq(double.inspect)
+        end
+
+        it "produces an inspected object when a matcher is missing a description" do
+          expect(ObjectInspector.inspect(matcher_without_a_description)).to eq(
+            matcher_without_a_description.inspect)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/support/spec/in_sub_process_spec.rb
+++ b/spec/rspec/support/spec/in_sub_process_spec.rb
@@ -1,9 +1,6 @@
-require 'rspec/support/spec/in_sub_process'
 require 'tempfile'
 
 describe 'isolating code to a sub process' do
-  include RSpec::Support::InSubProcess
-
   it 'isolates the block from the main process' do
     in_sub_process do
       module NotIsolated


### PR DESCRIPTION
Part of a larger effort originating from rspec/rspec-mocks#898 to pull Time, DateTime, and BigDecimal comparison code into a central location, and then apply across the entire rspec suite of projects.