### PR TITLE
Remove `color` definition that is redefined later in the file.

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -59,8 +59,9 @@ module RSpec
         diff_as_string(actual_as_string, expected_as_string)
       end
 
-      attr_reader :color
-      alias_method :color?, :color
+      def color?
+        @color
+      end
 
       def initialize(opts={})
         @color = opts.fetch(:color, false)


### PR DESCRIPTION
The `attr_reader :color` definition was only being used
so that we could define a `color?` alias, which seems kinda
silly.