### PR TITLE
Special case formatting for objects inside objects

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -1,5 +1,6 @@
 RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'hunk_generator'
+require 'rspec/matchers'
 
 require 'pp'
 
@@ -7,6 +8,9 @@ module RSpec
   module Support
     # rubocop:disable ClassLength
     class Differ
+      include RSpec::Matchers::BuiltIn::BaseMatcher::TimeFormatting
+      include RSpec::Matchers::BuiltIn::BaseMatcher::BigDecimalFormatting
+
       def diff(actual, expected)
         diff = ""
 

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -178,16 +178,38 @@ module RSpec
         end.join
       end
 
-      def object_to_string(object)
+      def format_objects_in_objects(object)
+        case
+        when Time === object
+          format_time(object)
+        when defined?(DateTime) && DateTime === object
+          format_date_time(object)
+        when defined?(BigDecimal) && BigDecimal === object
+          format_big_decimal(object)
+        when defined?(Hash) && Hash === object
+          "{#{object_to_string(object, true)}}"
+        else
+          object.inspect
+        end
+      end
+
+      def object_to_string(object, nested = false)
         object = @object_preparer.call(object)
         case object
         when Hash
-          object.keys.sort_by { |k| k.to_s }.map do |key|
-            pp_key   = PP.singleline_pp(key, "")
-            pp_value = PP.singleline_pp(object[key], "")
+          objects = object.keys.sort_by { |k| k.to_s }.map do |key|
+            pp_key   = format_objects_in_objects(key)
+            pp_value = format_objects_in_objects(object[key])
 
-            "#{pp_key} => #{pp_value},"
-          end.join("\n")
+            result = "#{pp_key} => #{pp_value}"
+            result = result + ',' unless nested
+            result
+          end
+          if nested
+            objects.join(', ')
+          else
+            objects.join("\n")
+          end
         when String
           object =~ /\n/ ? object : object.inspect
         else


### PR DESCRIPTION

On `rspec-expectations` some work had been done to improve the formatting of BigDecimal and Dates in expected failures.
However, this doesn't extend to objects of those types within Arrays and Hashes.

I've submitted a [pull request](https://github.com/rspec/rspec-expectations/pull/750) on rspec-expectations to resolve that.

That being said, the same kind of love should be extended to the differ in `rspec-support`, so here is my pull request trying to resolve it. 
That being said, there are probably better ways to do this, and my code might not reflect the current code style, but I thought this might at least get the ball rolling somewhat in terms of discussion, and I'm happy to fix it using suggestions provided.

#### Example Test

``` ruby
      it 'x' do
        require 'bigdecimal'
        require 'active_support'
        expect(
          {
            BigDecimal('3') => nil,
            DateTime.new(2015,1,1) => nil,
            nil => {
              BigDecimal('4') => nil
            }
          }
        ).to eq ({
            nil => {
              BigDecimal('4') => nil
            }
        })
      end
```

#### Old Output
```
  1) RSpec::Support::Differ x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7fa2bc280918,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7fa2bc280b70,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7fa2bc280aa8,'0.4E1',9(18)>)=>nil}}

       (compared using ==)

       Diff:
       @@ -1,2 +1,4 @@
       -nil => {#<BigDecimal:7fa2bc280918,'0.4E1',9(18)>=>nil},
       +nil => {#<BigDecimal:7fa2bc280aa8,'0.4E1',9(18)>=>nil},
       +#<BigDecimal:7fa2bc280b70,'0.3E1',9(18)> => nil,
       +#<DateTime: 2015-01-01T00:00:00+00:00 ((2457024j,0s,0n),+0s,2299161j)> => nil,
```

#### New
```
  1) RSpec::Support::Differ x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>)=>nil}}

       (compared using ==)

       Diff:
       @@ -1,2 +1,4 @@
       -nil => {4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>) => nil},
       +nil => {4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>) => nil},
       +3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>) => nil,
       +Thu, 01 Jan 2015 00:00:00.000000000 +0000 => nil,
```
