### PR TITLE
Extend ObjectInspector and have Differ use it for Hashes.

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -2,7 +2,7 @@ RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'hunk_generator'
 
 require 'pp'
-require 'rspec/support/object_inspector'
+RSpec::Support.require_rspec_support "object_inspector"
 
 module RSpec
   module Support

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -175,18 +175,19 @@ module RSpec
         end.join
       end
 
-      OBJECT_INSPECTOR_OPTIONS = {
-        :nested => false,
-        :joiner => ",\n",
-        :braces => false,
-        :trailing_comma => true
-      }
-
       def object_to_string(object)
         object = @object_preparer.call(object)
         case object
         when Hash
-          ObjectInspector.inspect(object, OBJECT_INSPECTOR_OPTIONS)
+          formatted_hash = ObjectInspector.formatter(object)
+          formatted_hash.keys.sort_by { |k| k.to_s }.map do |key|
+            pp_key   = PP.singleline_pp(key, "")
+            pp_value = PP.singleline_pp(formatted_hash[key], "")
+
+            "#{pp_key} => #{pp_value},"
+          end.join("\n")
+        when Array
+          PP.pp(ObjectInspector.formatter(object), "")
         when String
           object =~ /\n/ ? object : object.inspect
         else

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -179,13 +179,7 @@ module RSpec
         object = @object_preparer.call(object)
         case object
         when Hash
-          formatted_hash = ObjectInspector.formatter(object)
-          formatted_hash.keys.sort_by { |k| k.to_s }.map do |key|
-            pp_key   = PP.singleline_pp(key, "")
-            pp_value = PP.singleline_pp(formatted_hash[key], "")
-
-            "#{pp_key} => #{pp_value},"
-          end.join("\n")
+          hash_to_string(object)
         when Array
           PP.pp(ObjectInspector.formatter(object), "")
         when String
@@ -193,6 +187,16 @@ module RSpec
         else
           PP.pp(object, "")
         end
+      end
+
+      def hash_to_string(hash)
+        formatted_hash = ObjectInspector.formatter(hash)
+        formatted_hash.keys.sort_by { |k| k.to_s }.map do |key|
+          pp_key   = PP.singleline_pp(key, "")
+          pp_value = PP.singleline_pp(formatted_hash[key], "")
+
+          "#{pp_key} => #{pp_value},"
+        end.join("\n")
       end
 
       def handle_encoding_errors(actual, expected)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -2,6 +2,7 @@ RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'hunk_generator'
 
 require 'pp'
+require 'rspec/support/object_inspector'
 
 module RSpec
   module Support
@@ -174,16 +175,18 @@ module RSpec
         end.join
       end
 
+      OBJECT_INSPECTOR_OPTIONS = {
+        :nested => false,
+        :joiner => ",\n",
+        :braces => false,
+        :trailing_comma => true
+      }
+
       def object_to_string(object)
         object = @object_preparer.call(object)
         case object
         when Hash
-          object.keys.sort_by { |k| k.to_s }.map do |key|
-            pp_key   = PP.singleline_pp(key, "")
-            pp_value = PP.singleline_pp(object[key], "")
-
-            "#{pp_key} => #{pp_value},"
-          end.join("\n")
+          ObjectInspector.inspect(object, OBJECT_INSPECTOR_OPTIONS)
         when String
           object =~ /\n/ ? object : object.inspect
         else

--- a/lib/rspec/support/object_inspector.rb
+++ b/lib/rspec/support/object_inspector.rb
@@ -3,14 +3,21 @@ module RSpec
     # Provide additional output details beyond what `inspect` provides when
     # printing Time, DateTime, or BigDecimal
     module ObjectInspector
+      DEFAULT_OPTIONS = {
+        :nested => false,
+        :joiner => ',',
+        :braces => true,
+        :trailing_comma => false
+      }
       # @api private
       # rubocop:disable CyclomaticComplexity
       # rubocop:disable MethodLength
-
       def self.inspect(object, options=DEFAULT_OPTIONS)
         case object
         when Time
           format_time(object)
+        when Hash
+          format_hash(object, options)
         else
           if defined?(DateTime) && DateTime === object
             format_date_time(object)
@@ -29,6 +36,19 @@ module RSpec
       # rubocop:enable CyclomaticComplexity
       # rubocop:enable MethodLength
 
+      # @private
+      def self.format_hash(object, options)
+        nested_options = { :braces => true, :joiner => ', ' }
+
+        pairs = object.sort_by { |k, _| k.to_s }.map do |key, value|
+          "#{inspect(key, nested_options)} => #{inspect(value, nested_options)}"
+        end
+
+        results = pairs.join(options[:joiner])
+        results = "{#{results}}" if options[:braces]
+        results += ',' if options[:trailing_comma]
+        results
+      end
 
       TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/lib/rspec/support/object_inspector.rb
+++ b/lib/rspec/support/object_inspector.rb
@@ -46,7 +46,7 @@ module RSpec
 
         results = pairs.join(options[:joiner])
         results = "{#{results}}" if options[:braces]
-        results += ',' if options[:trailing_comma]
+        results << ',' if options[:trailing_comma]
         results
       end
 

--- a/lib/rspec/support/object_inspector.rb
+++ b/lib/rspec/support/object_inspector.rb
@@ -4,23 +4,31 @@ module RSpec
     # printing Time, DateTime, or BigDecimal
     module ObjectInspector
       # @api private
-      def self.inspect(object)
-        if Time === object
-          format_time(object)
-        elsif defined?(DateTime) && DateTime === object
-          format_date_time(object)
-        elsif defined?(BigDecimal) && BigDecimal === object
-          "#{object.to_s 'F'} (#{object.inspect})"
-        elsif RSpec::Support.is_a_matcher?(object) && object.respond_to?(:description)
-          object.description
-        else
-          registered_klasses.each do |klass, inspector|
-            return inspector.call(object) if klass === object
-          end
+      # rubocop:disable CyclomaticComplexity
+      # rubocop:disable MethodLength
 
-          object.inspect
+      def self.inspect(object, options=DEFAULT_OPTIONS)
+        case object
+        when Time
+          format_time(object)
+        else
+          if defined?(DateTime) && DateTime === object
+            format_date_time(object)
+          elsif defined?(BigDecimal) && BigDecimal === object
+            "#{object.to_s 'F'} (#{object.inspect})"
+          elsif RSpec::Support.is_a_matcher?(object) && object.respond_to?(:description)
+            object.description
+          else
+            registered_klasses.each do |klass, inspector|
+              return inspector.call(object) if klass === object
+            end
+            object.inspect
+          end
         end
       end
+      # rubocop:enable CyclomaticComplexity
+      # rubocop:enable MethodLength
+
 
       TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -279,12 +279,12 @@ EOD
         it "outputs unified diff message of two hashes with hashes inside them" do
           expected_diff = %Q{
 @@ -1,2 +1,2 @@
--"b" => {"key"=>"#{formatted_time}", "key1"=>"value"},
-+"c" => {"key"=>"#{formatted_time}", "key1"=>"value"},
+-"b" => {"key_1"=>"#{formatted_time}", "key_2"=>"value"},
++"c" => {"key_1"=>"#{formatted_time}", "key_2"=>"value"},
 }
 
-          left_side_hash = {'c' => {'key' => time, 'key1' => 'value'}}
-          right_side_hash = {'b' => {'key' => time, 'key1' => 'value'}}
+          left_side_hash = {'c' => {'key_1' => time, 'key_2' => 'value'}}
+          right_side_hash = {'b' => {'key_1' => time, 'key_2' => 'value'}}
           diff = differ.diff(left_side_hash, right_side_hash)
           expect(diff).to be_diffed_as(expected_diff)
         end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -263,13 +263,13 @@ EOD
 
       context 'when special-case objects are inside hashes' do
         let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
-        let(:formatted_time) { ObjectInspector.inspect(time) }
+        let(:formatted_time) { ObjectInspector.formatter(time) }
 
         it "outputs unified diff message of two hashes with Time object keys" do
           expected_diff = %Q{
 @@ -1,2 +1,2 @@
--#{formatted_time} => "b",
-+#{formatted_time} => "c",
+-"#{formatted_time}" => "b",
++"#{formatted_time}" => "c",
 }
 
           diff = differ.diff({ time => 'c'}, { time => 'b' })
@@ -279,13 +279,42 @@ EOD
         it "outputs unified diff message of two hashes with hashes inside them" do
           expected_diff = %Q{
 @@ -1,2 +1,2 @@
--"b" => {"key" => #{formatted_time}, "key1" => "value"},
-+"c" => {"key" => #{formatted_time}, "key1" => "value"},
+-"b" => {"key"=>"#{formatted_time}", "key1"=>"value"},
++"c" => {"key"=>"#{formatted_time}", "key1"=>"value"},
 }
 
           left_side_hash = {'c' => {'key' => time, 'key1' => 'value'}}
           right_side_hash = {'b' => {'key' => time, 'key1' => 'value'}}
           diff = differ.diff(left_side_hash, right_side_hash)
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+      end
+
+      context 'when special-case objects are inside arrays' do
+        let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
+        let(:formatted_time) { ObjectInspector.formatter(time) }
+
+        it "outputs unified diff message of two arrays with Time object keys" do
+          expected_diff = %Q{
+@@ -1,2 +1,2 @@
+-["#{formatted_time}", "b"]
++["#{formatted_time}", "c"]
+}
+
+          diff = differ.diff([time, 'c'], [time, 'b'])
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+
+        it "outputs unified diff message of two arrays with hashes inside them" do
+          expected_diff = %Q{
+@@ -1,2 +1,2 @@
+-[{"b"=>"#{formatted_time}"}, "c"]
++[{"a"=>"#{formatted_time}"}, "c"]
+}
+
+          left_side_array = [{'a' => time}, 'c']
+          right_side_array = [{'b' => time}, 'c']
+          diff = differ.diff(left_side_array, right_side_array)
           expect(diff).to be_diffed_as(expected_diff)
         end
       end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -261,6 +261,35 @@ EOD
           expect(diff).to be_diffed_as(expected_diff)
         end
 
+      context 'when special-case objects are inside hashes' do
+        let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
+        let(:formatted_time) { ObjectInspector.inspect(time) }
+
+        it "outputs unified diff message of two hashes with Time object keys" do
+          expected_diff = %Q{
+@@ -1,2 +1,2 @@
+-#{formatted_time} => "b",
++#{formatted_time} => "c",
+}
+
+          diff = differ.diff({ time => 'c'}, { time => 'b' })
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+
+        it "outputs unified diff message of two hashes with hashes inside them" do
+          expected_diff = %Q{
+@@ -1,2 +1,2 @@
+-"b" => {"key" => #{formatted_time}, "key1" => "value"},
++"c" => {"key" => #{formatted_time}, "key1" => "value"},
+}
+
+          left_side_hash = {'c' => {'key' => time, 'key1' => 'value'}}
+          right_side_hash = {'b' => {'key' => time, 'key1' => 'value'}}
+          diff = differ.diff(left_side_hash, right_side_hash)
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+      end
+
         it "outputs unified diff of multi line strings" do
           expected = "this is:\n  one string"
           actual   = "this is:\n  another string"

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -33,7 +33,7 @@ module RSpec
 
         it 'does not require DateTime to be defined since you need to require `date` to make it available' do
           hide_const('DateTime')
-          expect(ObjectInspector.inspect('Test String')).to eq('"Test String"')
+          expect(ObjectInspector.inspect('Test String')).to eq('Test String')
         end
 
         context 'when ActiveSupport is loaded' do
@@ -63,7 +63,7 @@ module RSpec
 
         it 'does not require BigDecimal to be defined since you need to require `bigdecimal` to make it available' do
           hide_const('BigDecimal')
-          expect(ObjectInspector.inspect('Test String')).to eq('"Test String"')
+          expect(ObjectInspector.inspect('Test String')).to eq('Test String')
         end
       end
 

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -80,6 +80,19 @@ module RSpec
         end
       end
 
+      context 'with Array Objects' do
+        let(:formatted_array) { ObjectInspector.inspect(array) }
+
+        describe 'inspecting objects inside array' do
+          let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
+          let(:array) { [ 5, { 'inner_key' => time }] }
+          let(:expected_formatting) { /\[5, {\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}\]/ }
+          it 'recursively uses itself to inspect objects within it' do
+            expect(formatted_array).to match(expected_formatting)
+          end
+        end
+      end
+
       context 'with objects that implement description' do
         RSpec::Matchers.define :matcher_with_description do
           match { true }

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -68,16 +68,7 @@ module RSpec
       end
 
       context 'with Hash Objects' do
-        let(:options) { { :nested => false, :joiner => ",\n", :braces => true } }
-        let(:formatted_hash) { ObjectInspector.inspect(hash, options) }
-
-        context 'with custom formatting' do
-          let(:hash) { { 'key1' => {'key2' => 2, 'key3' => 3}, 'key4' => 4 } }
-          let(:expected_formatting) { "{\"key1\" => {\"key2\" => 2, \"key3\" => 3},\n\"key4\" => 4}" }
-          it 'should apply the custom formatting correctly' do
-            expect(formatted_hash).to eq(expected_formatting)
-          end
-        end
+        let(:formatted_hash) { ObjectInspector.inspect(hash) }
 
         describe 'inspecting objects inside hashes' do
           let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -73,7 +73,7 @@ module RSpec
         describe 'inspecting objects inside hashes' do
           let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
           let(:hash) { { 'key' => { 'inner_key' => time } } }
-          let(:expected_formatting) { /{\"key\"=>{\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}}/ }
+          let(:expected_formatting) { /\{\"key\"=>\{\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}\}/ }
           it 'recursively uses itself to inspect objects within it' do
             expect(formatted_hash).to match(expected_formatting)
           end
@@ -86,7 +86,7 @@ module RSpec
         describe 'inspecting objects inside array' do
           let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
           let(:array) { [ 5, { 'inner_key' => time }] }
-          let(:expected_formatting) { /\[5, {\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}\]/ }
+          let(:expected_formatting) { /\[5, \{\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}\]/ }
           it 'recursively uses itself to inspect objects within it' do
             expect(formatted_array).to match(expected_formatting)
           end

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -67,6 +67,28 @@ module RSpec
         end
       end
 
+      context 'with Hash Objects' do
+        let(:options) { { :nested => false, :joiner => ",\n", :braces => true } }
+        let(:formatted_hash) { ObjectInspector.inspect(hash, options) }
+
+        context 'with custom formatting' do
+          let(:hash) { { 'key1' => {'key2' => 2, 'key3' => 3}, 'key4' => 4 } }
+          let(:expected_formatting) { "{\"key1\" => {\"key2\" => 2, \"key3\" => 3},\n\"key4\" => 4}" }
+          it 'should apply the custom formatting correctly' do
+            expect(formatted_hash).to eq(expected_formatting)
+          end
+        end
+
+        describe 'inspecting objects inside hashes' do
+          let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
+          let(:hash) { { 'key' => { 'inner_key' => time } } }
+          let(:expected_formatting) { /\"key\" => \{\"inner_key\" => 1969-12-31 19:01:40\.000101(000)? \+0000\}/ }
+          it 'recursively uses itself to inspect objects within it' do
+            expect(formatted_hash).to match(expected_formatting)
+          end
+        end
+      end
+
       context 'with objects that implement description' do
         RSpec::Matchers.define :matcher_with_description do
           match { true }

--- a/spec/rspec/support/object_inspector_spec.rb
+++ b/spec/rspec/support/object_inspector_spec.rb
@@ -73,7 +73,7 @@ module RSpec
         describe 'inspecting objects inside hashes' do
           let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
           let(:hash) { { 'key' => { 'inner_key' => time } } }
-          let(:expected_formatting) { /\"key\" => \{\"inner_key\" => 1969-12-31 19:01:40\.000101(000)? \+0000\}/ }
+          let(:expected_formatting) { /{\"key\"=>{\"inner_key\"=>"1969-12-31 19:01:40\.000101(000)? \+0000\"\}}/ }
           it 'recursively uses itself to inspect objects within it' do
             expect(formatted_hash).to match(expected_formatting)
           end


### PR DESCRIPTION
This PR updates how the ObjectInspector to handle the formatting inside of Arrays and Hashes.

It also updates the differ to use the ObjectInspector when it encounters a hash.
#### Example Test

``` ruby
      it 'x' do
        require 'bigdecimal'
        require 'active_support'
        expect(
          {
            BigDecimal('3') => nil,
            DateTime.new(2015,1,1) => nil,
            nil => {
              BigDecimal('4') => nil
            }
          }
        ).to eq ({
            nil => {
              BigDecimal('4') => nil
            }
        })
      end
```

#### Old Output
```
  1) RSpec::Support::Differ x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7fa2bc280918,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7fa2bc280b70,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7fa2bc280aa8,'0.4E1',9(18)>)=>nil}}

       (compared using ==)

       Diff:
       @@ -1,2 +1,4 @@
       -nil => {#<BigDecimal:7fa2bc280918,'0.4E1',9(18)>=>nil},
       +nil => {#<BigDecimal:7fa2bc280aa8,'0.4E1',9(18)>=>nil},
       +#<BigDecimal:7fa2bc280b70,'0.3E1',9(18)> => nil,
       +#<DateTime: 2015-01-01T00:00:00+00:00 ((2457024j,0s,0n),+0s,2299161j)> => nil,
```

#### New
```
  1) RSpec::Support::Differ x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>)=>nil}}

       (compared using ==)

       Diff:
       @@ -1,2 +1,4 @@
       -nil => {4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>) => nil},
       +nil => {4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>) => nil},
       +3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>) => nil,
       +Thu, 01 Jan 2015 00:00:00.000000000 +0000 => nil,
```
