### PR TITLE
Prefer calling `expected == actual` over `actual == expected`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ### Development
 
+Bug Fixes:
+
+* Fix `FuzzyMatcher` so that it checks `expected == actual` rather than
+  `actual == expected`, which avoids errors in situations where the
+  `actual` object's `==` is improperly implemented to assume that only
+  objects of the same type will be given. This allows rspec-mocks'
+  `anything` to match against objects with buggy `==` definitions.
+  (Myron Marston, #193)
+
 ### 3.2.2 / 2015-02-23
 
 Bug Fixes:

--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -12,7 +12,7 @@ module RSpec
           return arrays_match?(expected, actual.to_a)
         end
 
-        return true if actual == expected
+        return true if expected == actual
 
         begin
           expected === actual


### PR DESCRIPTION
This ensures that rspec-mocks' `anything` will always match,
even against objects that implement `==` wrongly.