### PR TITLE
Add `RSpec::Support.failure_notifier`.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 require 'rspec/support/spec'
 RSpec::Support::Spec.setup_simplecov
+
+RSpec::Matchers.define_negated_matcher :avoid_raising_errors, :raise_error
+RSpec::Matchers.define_negated_matcher :avoid_changing, :change


### PR DESCRIPTION
This is intended to support the new `aggregate_failures`
feature discussed in rspec/rspec-expectations#733. I
put the `failure_notifier` here so that rspec-mocks can
use it as well -- that way, when we are aggregating failures,
we can aggregate rspec-mocks failures as well.