### PR TITLE
Don’t bother with coverage on windows.

### DIFF
--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -46,7 +46,8 @@ module RSpec
         # Simplecov emits some ruby warnings when loaded, so silence them.
         old_verbose, $VERBOSE = $VERBOSE, false
 
-        return if ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3' || RUBY_ENGINE != 'ruby'
+        return if ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
+        return if RUBY_ENGINE != 'ruby' || RSpec::Support::OS.windows?
 
         # Don't load it when we're running a single isolated
         # test file rather than the whole suite.


### PR DESCRIPTION
My rspec-mocks build (for rspec/rspec-mocks#932) is
failing on AppVeyor because the “issues no warnings
when spec files are loaded” check is getting stdout/stderr
output from simplecov, in spite of the fact that we set
the NO_COVERAGE ENV var when we shell out for that.
I’m not sure why it doesn’t work on Windows but I don’t
care to spend a bunch of time to figure it out, given
I don’t have access to a windows box.