### PR TITLE
Stop using `example.fail`.

### DIFF
--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -21,8 +21,8 @@ RSpec.configure do |c|
       warning_preventer.reset!
     end
 
-    c.after do |example|
-      warning_preventer.verify_example!(example)
+    c.after do
+      warning_preventer.verify_no_warnings!
     end
   end
 

--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -15,7 +15,7 @@ module RSpec
 
             begin
               yield
-              warning_preventer.verify_example!(self) if prevent_warnings
+              warning_preventer.verify_no_warnings! if prevent_warnings
             rescue Exception => e
               exception = e
             end

--- a/lib/rspec/support/spec/stderr_splitter.rb
+++ b/lib/rspec/support/spec/stderr_splitter.rb
@@ -50,8 +50,8 @@ module RSpec
         @output_tracker = ::StringIO.new
       end
 
-      def verify_example!(example)
-        example.send(:fail, "Warnings were generated: #{output}") if has_output?
+      def verify_no_warnings!
+        raise "Warnings were generated: #{output}" if has_output?
         reset!
       end
 

--- a/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -34,7 +34,7 @@ describe 'RSpec::Support::StdErrSplitter' do
   end
 
   it 'acknowledges its own interface' do
-    expect(splitter).to respond_to :==, :write, :has_output?, :reset!, :verify_example!, :output
+    expect(splitter).to respond_to :==, :write, :has_output?, :reset!, :verify_no_warnings!, :output
   end
 
   it 'supports methods that stderr supports but StringIO does not' do
@@ -62,7 +62,7 @@ describe 'RSpec::Support::StdErrSplitter' do
 
       Tempfile.open('stderr') do |file|
         splitter.reopen(file)
-        expect { splitter.verify_example! self }.not_to raise_error
+        expect { splitter.verify_no_warnings! }.not_to raise_error
       end
     end
   end
@@ -73,19 +73,19 @@ describe 'RSpec::Support::StdErrSplitter' do
   end
 
   it 'will ignore examples without a warning' do
-    splitter.verify_example! self
+    splitter.verify_no_warnings!
   end
 
   it 'will ignore examples after a reset a warning' do
     warn 'a warning'
     splitter.reset!
-    splitter.verify_example! self
+    splitter.verify_no_warnings!
   end
 
   unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
     it 'will fail an example which generates a warning' do
       true unless @undefined
-      expect { splitter.verify_example! self }.to raise_error(/Warnings were generated:/)
+      expect { splitter.verify_no_warnings! }.to raise_error(/Warnings were generated:/)
     end
   end
 


### PR DESCRIPTION
- Originally, this was equivalent to `raise`.
- Since we have added `RSpec::Matchers::FailMatchers`,
  in spec suites that include that module, `fail` now
  returns an rspec matcher rather than raising.
- It’s simpler just to raise.