### PR TITLE
Fix race condition in mkdir_p

### DIFF
--- a/lib/rspec/support/directory_maker.rb
+++ b/lib/rspec/support/directory_maker.rb
@@ -16,6 +16,8 @@ module RSpec
           stack = generate_path(stack, part)
           begin
             Dir.mkdir(stack) unless directory_exists?(stack)
+          rescue Errno::EEXIST => e
+            raise e unless directory_exists?(stack)
           rescue Errno::ENOTDIR => e
             raise Errno::EEXIST, e.message
           end


### PR DESCRIPTION
This occurs quite often with parallel_rspec. Consider following sequence of the two processes P1, P2:

P1: directory_exists?('reports') -> false
P2: directory_exists?('reports') -> false
P2: Dir.mkdir('reports') -> true
P1: Dir.mkdir('reports') -> Errno:EEXIST: `mkdir': File exists - ./spec/reports