### PR TITLE
[WIP] spike showing failure notifier with options

### DIFF
--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -83,11 +83,11 @@ module RSpec
     end
 
     def self.failure_notifier
-      thread_local_data[:failure_notifier] ||= method(:raise)
+      thread_local_data[:failure_notifier] ||= lambda { |failure, _opts| method(:raise)(failure) }
     end
 
-    def self.notify_failure(failure)
-      failure_notifier.call(failure)
+    def self.notify_failure(failure, opts = {})
+      failure_notifier.call(failure, opts)
     end
 
     def self.with_failure_notifier(callable)


### PR DESCRIPTION
The idea would be that normally you'd just set the failure notifier to something like:

```Ruby
RSpec::Support.failure_notifier = proc { |failure| method(:raise)(failure) }
```

but that `aggregate_failures` would change to something like:

```Ruby
def call(failure, options = {})
  failure.set_backtrace(caller) unless failure.backtrace
  failures << failure unless options[:eager]
end
```