### PR TITLE
Include delegators in inspection output

### DIFF
--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -36,7 +36,7 @@ module RSpec
           elsif RSpec::Support.is_a_matcher?(object) && object.respond_to?(:description)
             inspection = object.description
           else
-            return object
+            return DelegatingInspector.new(object)
           end
         end
 
@@ -86,6 +86,21 @@ module RSpec
 
         def pretty_print(pp)
           pp.text inspection
+        end
+      end
+
+      # @private
+      DelegatingInspector = Struct.new(:object) do
+        def inspect
+          if defined?(::Delegator) && ::Delegator === object
+            "#<#{object.class}(#{ObjectFormatter.format(object.__getobj__)})>"
+          else
+            object.inspect
+          end
+        end
+
+        def pretty_print(pp)
+          pp.text inspect
         end
       end
     end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -393,6 +393,26 @@ EOD
           expect(diff).to be_a(String)
         end
 
+        it "includes object delegation information in the diff output" do
+          in_sub_process_if_possible do
+            require "delegate"
+
+            object = Object.new
+            delegator = SimpleDelegator.new(object)
+
+            expected_diff = dedent(<<-EOS)
+              |
+              |@@ -1,2 +1,2 @@
+              |-[#<SimpleDelegator(#{object.inspect})>]
+              |+[#{object.inspect}]
+              |
+            EOS
+
+            diff = differ.diff [object], [delegator]
+            expect(diff).to eq(expected_diff)
+          end
+        end
+
         context "with :object_preparer option set" do
           let(:differ) do
             RSpec::Support::Differ.new(:object_preparer => lambda { |s| s.to_s.reverse })

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -95,6 +95,44 @@ module RSpec
         end
       end
 
+      context 'given a delegator' do
+        def with_delegate_loaded
+          in_sub_process_if_possible do
+            require 'delegate'
+            yield
+          end
+        end
+
+        let(:object) { Object.new }
+        let(:delegator) do
+          SimpleDelegator.new(object)
+        end
+
+        it 'includes the delegator class in the description' do
+          with_delegate_loaded do
+            expect(ObjectFormatter.format(delegator)).to eq "#<SimpleDelegator(#{object.inspect})>"
+          end
+        end
+
+        it 'does not require Delegator to be defined' do
+          hide_const("Delegator")
+          expect(ObjectFormatter.format(object)).to eq object.inspect
+        end
+
+        context 'for a specially-formatted object' do
+          let(:decimal) { BigDecimal("3.3") }
+          let(:formatted_decimal) { ObjectFormatter.format(decimal) }
+          let(:object) { decimal }
+
+          it 'formats the underlying object normally' do
+            with_delegate_loaded do
+              require 'bigdecimal'
+              expect(ObjectFormatter.format(delegator)).to eq "#<SimpleDelegator(#{formatted_decimal})>"
+            end
+          end
+        end
+      end
+
       context 'with objects that implement description' do
         RSpec::Matchers.define :matcher_with_description do
           match { true }


### PR DESCRIPTION
In current spec output, it’s not immediately obvious when an object
under test is actually wrapped in a delegator of some sort, which can 
lead to some tricky-to-track-down failures on equality checks for two 
seemingly-identical objects.

The fix proposed here is to toss objects into a special wrapper when we 
prepare them for inspection. This wrapper recursively modifies the 
object’s inspection string with delegator class information, which
should make it much more apparent when the object under test is wrapped
by a delegator of some sort.

Related to https://github.com/rspec/rspec-core/issues/1995.