### PR TITLE
Fix spec so it always passes on 1.8.7.

### DIFF
--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -279,12 +279,12 @@ EOD
         it "outputs unified diff message of two hashes with hashes inside them" do
           expected_diff = %Q{
 @@ -1,2 +1,2 @@
--"b" => {"key_1"=>#{formatted_time}, "key_2"=>"value"},
-+"c" => {"key_1"=>#{formatted_time}, "key_2"=>"value"},
+-"b" => {"key_1"=>#{formatted_time}},
++"c" => {"key_1"=>#{formatted_time}},
 }
 
-          left_side_hash = {'c' => {'key_1' => time, 'key_2' => 'value'}}
-          right_side_hash = {'b' => {'key_1' => time, 'key_2' => 'value'}}
+          left_side_hash = {'c' => {'key_1' => time}}
+          right_side_hash = {'b' => {'key_1' => time}}
           diff = differ.diff(left_side_hash, right_side_hash)
           expect(diff).to be_diffed_as(expected_diff)
         end


### PR DESCRIPTION
It failed on travis:

https://travis-ci.org/rspec/rspec-support/jobs/67086677

Hashes are unordered on 1.8.7 so the output order is non-deterministic.
For this spec it is not important that the hash has multiple entries,
so limiting it to one makes the output on all rubies deterministic.