### PR TITLE
Work around JRuby `Method#parameters` bug.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ Enhancements:
 * Improve formatting of `Delegator` based objects (e.g. `SimpleDelgator`) in
   failure messages and diffs. (Andrew Horner, #215)
 
+Bug Fixes:
+
+* Work around bug in JRuby that reports that `attr_writer` methods
+  have no parameters, causing RSpec's verifying doubles to wrongly
+  fail when mocking or stubbing a writer method on JRuby. (Myron Marston, #225)
 
 ### 3.3.0 / 2015-06-12
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.2.2...v3.3.0)

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -136,6 +136,23 @@ module RSpec
       INFINITY = 1 / 0.0
     end
 
+    # Some versions of JRuby have a nasty bug we have to work around :(.
+    # https://github.com/jruby/jruby/issues/2816
+    if RSpec::Support::Ruby.jruby? &&
+       RubyFeatures.optional_and_splat_args_supported? &&
+       Class.new { attr_writer :foo }.instance_method(:foo=).parameters == []
+
+      class MethodSignature < remove_const(:MethodSignature)
+      private
+
+        def classify_parameters
+          super
+          return unless @method.parameters == [] && @method.arity == 1
+          @max_non_kw_args = @min_non_kw_args = 1
+        end
+      end
+    end
+
     # Deals with the slightly different semantics of block arguments.
     # For methods, arguments are required unless a default value is provided.
     # For blocks, arguments are optional, even if no default value is provided.

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -295,6 +295,23 @@ module RSpec
             expect(error_description).to eq("1")
           end
         end
+
+        describe 'an `attr_writer` method' do
+          attr_writer :foo
+          let(:test_method) { method(:foo=) }
+
+          it 'validates against a single argument' do
+            expect(valid_non_kw_args?(1)).to eq true
+          end
+
+          it 'fails validation against 0 arguments' do
+            expect(valid_non_kw_args?(0)).to eq false
+          end
+
+          it 'fails validation against 2 arguments' do
+            expect(valid_non_kw_args?(2)).to eq false
+          end
+        end
       end
 
       let(:fake_matcher) { Object.new }


### PR DESCRIPTION
See jruby/jruby#2816 and rspec/rspec-mocks#919 for
a discussion of the bug. This is affecting us now that
I’m trying to enable partial double verification for
rspec-core (rspec/rspec-core#2032) so I thought it worth
addressing.