### PR TITLE
Update rubocop to latest with Ruby 2.2 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,14 @@ inherit_from: .rubocop_rspec_base.yml
 Lint/NonLocalExitFromIterator:
   Enabled: false
 
+# Over time we'd like to get this down, but this is what we're at now.
+Metrics/AbcSize:
+  Max: 22
+
+# Over time we'd like to get this down, but this is what we're at now.
+Metrics/PerceivedComplexity:
+  Max: 9
+
 # We don't care about single vs double qoutes.
 Style/StringLiteralsInInterpolation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: .rubocop_rspec_base.yml
+
+Lint/NonLocalExitFromIterator:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,7 @@ inherit_from: .rubocop_rspec_base.yml
 
 Lint/NonLocalExitFromIterator:
   Enabled: false
+
+# We don't care about single vs double qoutes.
+Style/StringLiteralsInInterpolation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,6 @@ Metrics/PerceivedComplexity:
 # We don't care about single vs double qoutes.
 Style/StringLiteralsInInterpolation:
   Enabled: false
+
+Style/SymbolProc:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ cache:
     - ../bundle
 before_install:
   - "script/clone_all_rspec_repos"
-  # Downgrade bundler to work around https://github.com/bundler/bundler/issues/3004
   # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it
-  - if [ -z "$JRUBY_OPTS" ]; then gem install bundler -v=1.5.3 && alias bundle="bundle _1.5.3_"; fi
+  - if [ "jruby" != "$TRAVIS_RUBY_VERSION" ]; then gem install bundler; fi
 bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 script: "script/run_build"
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ end
 ### dep for ci/coverage
 gem 'simplecov', '~> 0.8'
 
-gem 'rubocop', "~> 0.23.0", :platform => [:ruby_19, :ruby_20, :ruby_21]
+# There is no platform :ruby_193 and Rubocop only supports >= 1.9.3
+unless RUBY_VERSION == "1.9.2"
+  gem "rubocop",
+      "~> 0.32.1",
+      :platform => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/benchmarks/parallel_vs_sequential_assignment.rb
+++ b/benchmarks/parallel_vs_sequential_assignment.rb
@@ -1,0 +1,291 @@
+require 'benchmark'
+
+class SequentialWidget
+  def initialize
+    a = 1
+    b = 2
+  end
+end
+
+def sequential_initialize_assignment
+  SequentialWidget.new
+end
+
+class ParallelWidget
+  def initialize
+    a, b = 1, 2
+  end
+end
+
+def parallel_initialize_assignment
+  ParallelWidget.new
+end
+
+def sequential_local_assignment
+  a = 1
+  b = 2
+  # Simulate that the assignment is not the method return value but do
+  # not add more work to this method
+  :noop
+end
+
+def parallel_local_assignment
+  a, b = 1, 2
+  # Simulate that the assignment is not the method return value but do
+  # not add more work to this method
+  :noop
+end
+
+def sequential_block_assignment
+  a = nil
+  b = nil
+  (1..10).each do |x|
+    a = b
+    b = x
+  end
+  # Simulate that the assignment is not the method return value but do
+  # not add more work to this method
+  :noop
+end
+
+def parallel_block_assignment
+  a = nil
+  b = nil
+  (1..10).each do |x|
+    a, b = b, x
+  end
+  # Simulate that the assignment is not the method return value but do
+  # not add more work to this method
+  :noop
+end
+
+
+puts
+puts "Ruby #{RUBY_VERSION}"
+puts
+begin
+  require 'benchmark/ips'
+
+  Benchmark.ips do |x|
+    x.report('Parallel Local Assignment       ') do
+      parallel_local_assignment
+    end
+
+    x.report('Sequential Local Assignment     ') do
+      sequential_local_assignment
+    end
+
+    x.compare!
+  end
+
+  Benchmark.ips do |x|
+    x.report('Parallel Initialize Assignment  ') do
+      parallel_initialize_assignment
+    end
+
+    x.report('Sequential Initialize Assignment') do
+      sequential_initialize_assignment
+    end
+
+    x.compare!
+  end
+
+  Benchmark.ips do |x|
+    x.report('Parallel Block Assignment       ') do
+      parallel_block_assignment
+    end
+
+    x.report('Sequential Block Assignment     ') do
+      sequential_block_assignment
+    end
+
+    x.compare!
+  end
+
+rescue LoadError
+
+  # We are on an older Ruby which does not support benchmark/ips
+  n = 100_000
+
+  puts "#{n} times"
+
+  Benchmark.benchmark do |bm|
+    puts
+    puts "Parallel Local Assignment"
+    3.times { bm.report { n.times { parallel_local_assignment } } }
+
+    puts
+    puts "Sequential Local Assignment"
+    3.times { bm.report { n.times { sequential_local_assignment } } }
+  end
+
+  Benchmark.benchmark do |bm|
+    puts
+    puts "Parallel Initialize Assignment"
+    3.times { bm.report { n.times { parallel_initialize_assignment } } }
+
+    puts
+    puts "Sequential Initialize Assignment"
+    3.times { bm.report { n.times { sequential_initialize_assignment } } }
+  end
+
+  Benchmark.benchmark do |bm|
+    puts
+    puts "Parallel Block Assignment"
+    3.times { bm.report { n.times { parallel_block_assignment } } }
+
+    puts
+    puts "Sequential Block Assignment"
+    3.times { bm.report { n.times { sequential_block_assignment } } }
+  end
+end
+
+__END__
+
+This is a complicated benchmark. Sequential assignment is always faster on Ruby
+1.8.7, REE, and JRuby. However, on Ruby 1.9 and 2.x it depends where the
+assignment is used - and how many assignments are made.
+
+On Ruby 1.9 and 2.x the assignment of two variable is essentially equally fast
+for parallel and sequent. However, as the number of assignments go up parallel
+assignment becomes increasingly faster. However, it depends on the context of
+that assignment. If the assignment LOC is also an _**implicit**_ return, thus
+if it's the last line of a method or a block (this is true for blocks even when
+the block return value is ignored), then Ruby will return all variable values
+as an array! This array creation is slow and will make sequential assignment
+faster, as the incidental array is not created.
+
+Given that there is little benefit for the common case of parallel assignment
+for two varaibles, and it's less common to see parallel assignment for three
+variables, and extremely rare for any number greater we should default to
+sequential assignment. [Aaron Kromer]
+
+Ruby 1.8.7
+
+100000 times
+
+Parallel Local Assignment
+  0.080000   0.000000   0.080000 (  0.079573)
+  0.060000   0.000000   0.060000 (  0.067334)
+  0.060000   0.000000   0.060000 (  0.059873)
+
+Sequential Local Assignment
+  0.030000   0.000000   0.030000 (  0.030429)
+  0.030000   0.010000   0.040000 (  0.030158)
+  0.020000   0.000000   0.020000 (  0.023209)
+
+Parallel Initialize Assignment
+  0.090000   0.000000   0.090000 (  0.085544)
+  0.080000   0.000000   0.080000 (  0.084318)
+  0.080000   0.000000   0.080000 (  0.085762)
+
+Sequential Initialize Assignment
+  0.050000   0.000000   0.050000 (  0.048160)
+  0.050000   0.000000   0.050000 (  0.049463)
+  0.050000   0.000000   0.050000 (  0.051358)
+
+Parallel Block Assignment
+  0.460000   0.000000   0.460000 (  0.469698)
+  0.460000   0.000000   0.460000 (  0.457632)
+  0.450000   0.010000   0.460000 (  0.462481)
+
+Sequential Block Assignment
+  0.230000   0.000000   0.230000 (  0.240600)
+  0.230000   0.000000   0.230000 (  0.245943)
+  0.230000   0.000000   0.230000 (  0.230579)
+
+
+Ruby 1.9.3
+
+Calculating -------------------------------------
+Parallel Local Assignment
+                        89.220k i/100ms
+Sequential Local Assignment
+                        91.383k i/100ms
+-------------------------------------------------
+Parallel Local Assignment
+                          5.075M (± 8.8%) i/s -     25.249M
+Sequential Local Assignment
+                          5.029M (±12.1%) i/s -     24.673M
+
+Comparison:
+Parallel Local Assignment       :  5074905.9 i/s
+Sequential Local Assignment     :  5028923.8 i/s - 1.01x slower
+
+Calculating -------------------------------------
+Parallel Initialize Assignment
+                        61.930k i/100ms
+Sequential Initialize Assignment
+                        66.286k i/100ms
+-------------------------------------------------
+Parallel Initialize Assignment
+                          1.943M (± 5.3%) i/s -      9.723M
+Sequential Initialize Assignment
+                          2.124M (± 9.8%) i/s -     10.606M
+
+Comparison:
+Sequential Initialize Assignment:  2123826.3 i/s
+Parallel Initialize Assignment  :  1943162.0 i/s - 1.09x slower
+
+Calculating -------------------------------------
+Parallel Block Assignment
+                        30.497k i/100ms
+Sequential Block Assignment
+                        36.997k i/100ms
+-------------------------------------------------
+Parallel Block Assignment
+                        579.905k (± 7.7%) i/s -      2.897M
+Sequential Block Assignment
+                        896.073k (± 7.7%) i/s -      4.477M
+
+Comparison:
+Sequential Block Assignment     :   896072.9 i/s
+Parallel Block Assignment       :   579904.9 i/s - 1.55x slower
+
+
+Ruby 2.2.2
+
+Calculating -------------------------------------
+Parallel Local Assignment
+                        83.984k i/100ms
+Sequential Local Assignment
+                        86.309k i/100ms
+-------------------------------------------------
+Parallel Local Assignment
+                          5.602M (±12.0%) i/s -     27.043M
+Sequential Local Assignment
+                          5.482M (± 8.0%) i/s -     27.274M
+
+Comparison:
+Parallel Local Assignment       :  5602180.9 i/s
+Sequential Local Assignment     :  5482370.9 i/s - 1.02x slower
+
+Calculating -------------------------------------
+Parallel Initialize Assignment
+                        64.000k i/100ms
+Sequential Initialize Assignment
+                        67.066k i/100ms
+-------------------------------------------------
+Parallel Initialize Assignment
+                          2.044M (± 5.5%) i/s -     10.240M
+Sequential Initialize Assignment
+                          2.488M (± 6.3%) i/s -     12.407M
+
+Comparison:
+Sequential Initialize Assignment:  2487575.1 i/s
+Parallel Initialize Assignment  :  2044428.9 i/s - 1.22x slower
+
+Calculating -------------------------------------
+Parallel Block Assignment
+                        34.362k i/100ms
+Sequential Block Assignment
+                        45.586k i/100ms
+-------------------------------------------------
+Parallel Block Assignment
+                        593.794k (± 4.5%) i/s -      2.989M
+Sequential Block Assignment
+                        886.536k (±12.3%) i/s -      4.331M
+
+Comparison:
+Sequential Block Assignment     :   886535.9 i/s
+Parallel Block Assignment       :   593793.6 i/s - 1.49x slower

--- a/benchmarks/symbol_to_proc_vs_block.rb
+++ b/benchmarks/symbol_to_proc_vs_block.rb
@@ -1,0 +1,329 @@
+require 'benchmark'
+
+RANGE = (1..100)
+
+def sym_to_proc_with_map
+  RANGE.map(&:to_s)
+end
+
+def sym_to_proc_with_each
+  RANGE.each(&:to_s)
+end
+
+def block_with_map
+  RANGE.map { |i| i.to_s }
+end
+
+def block_with_each
+  RANGE.each { |i| i.to_s }
+end
+
+begin
+  require 'benchmark/ips'
+
+  [10, 100, 1000, 10_000].each do |size|
+    range = (1..size)
+
+    puts "\nUsing Array#map size #{size}:"
+    Benchmark.ips do |x|
+      x.report('Block         ') { range.map { |i| i.to_s } }
+      x.report('Symbol#to_proc') { range.map(&:to_s) }
+      x.compare!
+    end
+
+    puts "Using Array#each size #{size}:"
+    Benchmark.ips do |x|
+      x.report('Block         ') { range.each { |i| i.to_s } }
+      x.report('Symbol#to_proc') { range.each(&:to_s) }
+      x.compare!
+    end
+  end
+rescue LoadError
+  # We are on an older Ruby which does not support benchmark/ips
+  n = 100_000
+
+  Benchmark.benchmark do |bm|
+    puts
+    puts "#{n} times - ruby #{RUBY_VERSION}"
+
+    puts
+    puts "symbol to proc (map)"
+    3.times { bm.report { n.times { sym_to_proc_with_map } } }
+
+    puts
+    puts "block (map)"
+    3.times { bm.report { n.times { block_with_map } } }
+
+    puts
+    puts "symbol to proc (each)"
+    3.times { bm.report { n.times { sym_to_proc_with_each } } }
+
+    puts
+    puts "block (each)"
+    3.times { bm.report { n.times { block_with_each } } }
+  end
+end
+
+__END__
+
+I was very surprised by this benchmark. My memory seemed to always remember
+being told that using a block was faster than calling symbol to proc. This was
+true for Ruby 1.8.7 (including REE and JRuby) but was not true for Ruby 1.9 and
+2.0, 2.1, and 2.2. For Ruby 1.9 and 2.x sometimes the block was faster for
+small enumerable sizes, but the difference in those cases was negligable.
+
+A larger list of benchmarks is available in the output reported by the
+following Travis CI build:
+
+https://travis-ci.org/rspec/rspec-support/builds/73746126
+
+It seems that going forward it is likely that we should switch to using symbol
+to proc. [Aaron Kromer]
+
+
+100000 times - ruby 1.8.7
+
+symbol to proc (map)
+  8.010000   0.040000   8.050000 (  8.085102)
+  8.260000   0.030000   8.290000 (  8.343247)
+  8.510000   0.060000   8.570000 (  8.790371)
+
+block (map)
+  5.530000   0.040000   5.570000 (  5.637928)
+  5.540000   0.040000   5.580000 (  5.652807)
+  5.530000   0.040000   5.570000 (  5.647678)
+
+symbol to proc (each)
+  6.410000   0.050000   6.460000 (  6.568056)
+  6.430000   0.040000   6.470000 (  6.544043)
+  6.380000   0.040000   6.420000 (  6.470070)
+
+block (each)
+  4.230000   0.020000   4.250000 (  4.273692)
+  4.210000   0.020000   4.230000 (  4.255388)
+  4.220000   0.020000   4.240000 (  4.264383)
+
+
+ruby 1.9.3p547 (2014-05-14) [x86_64-darwin14.0.0]
+Using Array#map size 10:
+  Comparison:
+        Block         :   225844.6 i/s
+        Symbol#to_proc:   224433.3 i/s - 1.01x slower
+
+Using Array#each size 10:
+  Comparison:
+        Symbol#to_proc:   359495.0 i/s
+        Block         :   317313.7 i/s - 1.13x slower
+
+
+Using Array#map size 100:
+  Comparison:
+        Symbol#to_proc:    28015.5 i/s
+        Block         :    26334.1 i/s - 1.06x slower
+
+Using Array#each size 100:
+  Comparison:
+        Symbol#to_proc:    38636.7 i/s
+        Block         :    32242.8 i/s - 1.20x slower
+
+
+Using Array#map size 1000:
+  Comparison:
+        Symbol#to_proc:     3720.9 i/s
+        Block         :     3388.1 i/s - 1.10x slower
+
+Using Array#each size 1000:
+  Comparison:
+        Symbol#to_proc:     5116.9 i/s
+        Block         :     4087.2 i/s - 1.25x slower
+
+
+Using Array#map size 10000:
+  Comparison:
+        Symbol#to_proc:      359.8 i/s
+        Block         :      258.5 i/s - 1.39x slower
+
+Using Array#each size 10000:
+  Comparison:
+        Symbol#to_proc:      470.1 i/s
+        Block         :      388.6 i/s - 1.21x slower
+
+
+ruby 2.0.0p576 (2014-09-19) [x86_64-darwin14.0.0]
+Using Array#map size 10:
+  Comparison:
+        Block         :   234459.4 i/s
+        Symbol#to_proc:   232139.1 i/s - 1.01x slower
+
+Using Array#each size 10:
+  Comparison:
+        Symbol#to_proc:   365396.5 i/s
+        Block         :   341559.2 i/s - 1.07x slower
+
+
+Using Array#map size 100:
+  Comparison:
+        Symbol#to_proc:    28839.2 i/s
+        Block         :    27606.0 i/s - 1.04x slower
+
+Using Array#each size 100:
+  Comparison:
+        Symbol#to_proc:    40908.2 i/s
+        Block         :    36646.3 i/s - 1.12x slower
+
+
+Using Array#map size 1000:
+  Comparison:
+        Symbol#to_proc:     2446.4 i/s
+        Block         :     2149.2 i/s - 1.14x slower
+
+Using Array#each size 1000:
+  Comparison:
+        Symbol#to_proc:     3747.5 i/s
+        Block         :     3030.8 i/s - 1.24x slower
+
+
+Using Array#map size 10000:
+  Comparison:
+        Symbol#to_proc:      356.3 i/s
+        Block         :      336.7 i/s - 1.06x slower
+
+Using Array#each size 10000:
+  Comparison:
+        Symbol#to_proc:      485.6 i/s
+        Block         :      414.0 i/s - 1.17x slower
+
+
+ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-darwin14.0]
+Using Array#map size 10:
+  Comparison:
+        Symbol#to_proc:   232131.3 i/s
+        Block         :   226938.7 i/s - 1.02x slower
+
+Using Array#each size 10:
+  Comparison:
+        Symbol#to_proc:   406072.3 i/s
+        Block         :   382604.5 i/s - 1.06x slower
+
+
+Using Array#map size 100:
+  Comparison:
+        Symbol#to_proc:    36333.6 i/s
+        Block         :    31873.8 i/s - 1.14x slower
+
+Using Array#each size 100:
+  Comparison:
+        Symbol#to_proc:    52197.2 i/s
+        Block         :    43321.5 i/s - 1.20x slower
+
+
+Using Array#map size 1000:
+  Comparison:
+        Symbol#to_proc:     3119.2 i/s
+        Block         :     2896.9 i/s - 1.08x slower
+
+Using Array#each size 1000:
+  Comparison:
+        Symbol#to_proc:     4161.0 i/s
+        Block         :     3942.1 i/s - 1.06x slower
+
+
+Using Array#map size 10000:
+  Comparison:
+        Symbol#to_proc:      311.5 i/s
+        Block         :      199.0 i/s - 1.57x slower
+
+Using Array#each size 10000:
+  Comparison:
+        Symbol#to_proc:      507.8 i/s
+        Block         :      426.2 i/s - 1.19x slower
+
+
+ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]
+Using Array#map size 10:
+  Comparison:
+        Block         :   275271.0 i/s
+        Symbol#to_proc:   261591.5 i/s - 1.05x slower
+
+Using Array#each size 10:
+  Comparison:
+        Symbol#to_proc:   512647.5 i/s
+        Block         :   470755.8 i/s - 1.09x slower
+
+
+Using Array#map size 100:
+  Comparison:
+        Symbol#to_proc:    37350.5 i/s
+        Block         :    36772.7 i/s - 1.02x slower
+
+Using Array#each size 100:
+  Comparison:
+        Symbol#to_proc:    58635.6 i/s
+        Block         :    50240.9 i/s - 1.17x slower
+
+
+Using Array#map size 1000:
+  Comparison:
+        Block         :     3715.4 i/s
+        Symbol#to_proc:     3677.0 i/s - 1.01x slower
+
+Using Array#each size 1000:
+  Comparison:
+        Symbol#to_proc:     5587.5 i/s
+        Block         :     4597.9 i/s - 1.22x slower
+
+
+Using Array#map size 10000:
+  Comparison:
+        Symbol#to_proc:      355.2 i/s
+        Block         :      339.1 i/s - 1.05x slower
+
+Using Array#each size 10000:
+  Comparison:
+        Symbol#to_proc:      518.2 i/s
+        Block         :      444.1 i/s - 1.17x slower
+
+
+ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]
+Using Array#map size 10:
+  Comparison:
+        Symbol#to_proc:   298189.1 i/s
+        Block         :   295415.7 i/s - 1.01x slower
+
+Using Array#each size 10:
+  Comparison:
+        Symbol#to_proc:   517869.4 i/s
+        Block         :   449633.0 i/s - 1.15x slower
+
+
+Using Array#map size 100:
+  Comparison:
+        Symbol#to_proc:    33502.5 i/s
+        Block         :    31585.9 i/s - 1.06x slower
+
+Using Array#each size 100:
+  Comparison:
+        Symbol#to_proc:    54738.3 i/s
+        Block         :    44457.9 i/s - 1.23x slower
+
+
+Using Array#map size 1000:
+  Comparison:
+        Symbol#to_proc:     3431.9 i/s
+        Block         :     3190.7 i/s - 1.08x slower
+
+Using Array#each size 1000:
+  Comparison:
+        Symbol#to_proc:     5590.9 i/s
+        Block         :     4660.6 i/s - 1.20x slower
+
+
+Using Array#map size 10000:
+  Comparison:
+        Symbol#to_proc:      353.3 i/s
+        Block         :      344.5 i/s - 1.03x slower
+
+Using Array#each size 10000:
+  Comparison:
+        Symbol#to_proc:      526.5 i/s
+        Block         :      437.1 i/s - 1.20x slower

--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -69,7 +69,7 @@ module RSpec
           return line.to_s if line
 
           skip_frames += increment
-          increment   *= 2 # The choice of two here is arbitrary.
+          increment *= 2 # The choice of two here is arbitrary.
         end
       end
     else

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -95,7 +95,7 @@ module RSpec
             end
           end
 
-          @max_non_kw_args = @min_non_kw_args  + optional_non_kw_args
+          @max_non_kw_args = @min_non_kw_args + optional_non_kw_args
           @allowed_kw_args = @required_kw_args + @optional_kw_args
         end
       else

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -6,7 +6,7 @@ module RSpec
     #
     # Provides query methods for different OS or OS features.
     module OS
-      module_function
+    module_function
 
       def windows?
         !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
@@ -21,7 +21,7 @@ module RSpec
     #
     # Provides query methods for different rubies
     module Ruby
-      module_function
+    module_function
 
       def jruby?
         RUBY_PLATFORM == 'java'
@@ -45,7 +45,7 @@ module RSpec
     # Provides query methods for ruby features that differ among
     # implementations.
     module RubyFeatures
-      module_function
+    module_function
 
       def optional_and_splat_args_supported?
         Method.method_defined?(:parameters)

--- a/lib/rspec/support/spec/string_matcher.rb
+++ b/lib/rspec/support/spec/string_matcher.rb
@@ -4,7 +4,6 @@ require 'rspec/matchers'
 # which also relies on EncodedString. Instead, confirm the
 # strings have the same bytes.
 RSpec::Matchers.define :be_identical_string do |expected|
-
   if String.method_defined?(:encoding)
     match do
       expected_encoding? &&

--- a/lib/rspec/support/version_checker.rb
+++ b/lib/rspec/support/version_checker.rb
@@ -5,7 +5,8 @@ module RSpec
     # @private
     class VersionChecker
       def initialize(library_name, library_version, min_patch_level)
-        @library_name, @library_version = library_name, library_version
+        @library_name = library_name
+        @library_version = library_version
         @min_patch_level = min_patch_level
 
         @major,     @minor,     @patch     = parse_version(library_version)


### PR DESCRIPTION
This updates Rubocop from 0.23.0 to 0.32.1 (most recent).

Unfortunately, in order to support this new version, which includes several bug fixes and support for Ruby 2.2, we need to drop support on Ruby 1.9.2. In fact Rubocop dropped 1.9.2 support as of version 0.25.0.

Some additional new cops are now available:
- Metrics/AbcSize (Assignment Branch Condition)
- Metrics/PerceivedComplexity

There are three additional new cops but they have been disabled (these settings should be ported to rspec-dev as part of the project defaults):
- Lint/NonLocalExitFromIterator
  
  This has been disabled due it's inability to distinguish between when / where `return` is sent from within a block. For example, a DSL block which has an explicit return in a method definition triggers this cop:
  
  ``` ruby
  some_method do
    def a_local_method
      return if true # triggers cop even though `return` will not exit from the block
    end
  end
  ```
- Style/ParallelAssignment
  
  Rubocop suggested this because it believed that parallel assignment was slower than sequential assignment. Unfortunately the benchmark they reference is flawed due to how Ruby handles implicit returns. It turns out that parallel assignment is _faster_.
- Style/StringLiteralsInInterpolation
  
  We previously disabled the related cop Style/StringLiterals. We simply don't care about single vs double qoutes.

See also: rspec/rspec-dev#134
