### PR TITLE
FuzzyMatcher is friendly to custom classes subclassed from Array

### DIFF
--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -6,9 +6,11 @@ module RSpec
     module FuzzyMatcher
       # @api private
       def self.values_match?(expected, actual)
-        if Hash === actual
-          return hashes_match?(expected, actual) if Hash === expected
-        elsif Array === expected && Enumerable === actual && !(Struct === actual)
+        if actual.instance_of?(Hash)
+          return hashes_match?(expected, actual) if expected.instance_of?(Hash)
+        elsif expected.instance_of?(Array) && actual.instance_of?(Array)
+          return arrays_match?(expected, actual)
+        elsif expected.instance_of?(Array) && Enumerable === actual && !(Struct === actual)
           return arrays_match?(expected, actual.to_a)
         end
 


### PR DESCRIPTION
The semantics of `FuzzyMatcher`'s comparison algorithm are problematic for custom classes which subclass from `Array`. This commit adjusts `FuzzyMatcher` to make its behavior on subclasses of `Array` more intuitive.

This is the commit log message:

When comparing subclasses of `Array`, `FuzzyMatcher` would call `#to_a` on one object
but not both, which could cause the comparison to fail if `#to_a` was overridden.
Additionally, some subclasses of `Array` may define their own idea of 'equality',
which should be respected by `FuzzyMatcher`.

On the other hand, if the 'expected' value is an `Array`, it is reasonable to
coerce the subclass of `Array` to an actual `Array`. Since `Enumerable` does not
define `#to_ary`, but only `#to_a`, use `#to_a` for this purpose.