### PR TITLE
Implement granular expectations for method signatures

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -8,7 +8,7 @@ module RSpec
     # keyword args of a given method.
     #
     # @private
-    class MethodSignature
+    class MethodSignature # rubocop:disable ClassLength
       attr_reader :min_non_kw_args, :max_non_kw_args, :optional_kw_args, :required_kw_args
 
       def initialize(method)
@@ -196,7 +196,10 @@ module RSpec
       end
 
       def empty?
-        @count.nil? && @keywords.to_a.empty? && !@expect_arbitrary_keywords && !@expect_unlimited_arguments
+        @count.nil? &&
+          @keywords.to_a.empty? &&
+          !@expect_arbitrary_keywords &&
+          !@expect_unlimited_arguments
       end
 
       def keywords=(values)
@@ -234,22 +237,28 @@ module RSpec
         @arbitrary_kw_args = @unlimited_args = false
       end
 
-      def with_expectation(expectation)
+      def with_expectation(expectation) # rubocop:disable MethodLength
         return self unless MethodSignatureExpectation === expectation
 
         if expectation.empty?
           @non_kw_args = nil
           @kw_args     = []
-        elsif RubyFeatures.kw_args_supported?
-          @non_kw_args       = expectation.count || 0
-          @kw_args           = expectation.keywords
-          @arbitrary_kw_args = expectation.expect_arbitrary_keywords
-          @unlimited_args    = expectation.expect_unlimited_arguments
         else
-          @non_kw_args       = expectation.count
-          @kw_args           = []
-          @arbitrary_kw_args = false
-          @unlimited_args    = expectation.expect_unlimited_arguments
+          @non_kw_args    = expectation.count || 0
+
+          if RubyFeatures.optional_and_splat_args_supported?
+            @unlimited_args = expectation.expect_unlimited_arguments
+          else
+            @unlimited_args = false
+          end
+
+          if RubyFeatures.kw_args_supported?
+            @kw_args           = expectation.keywords
+            @arbitrary_kw_args = expectation.expect_arbitrary_keywords
+          else
+            @kw_args           = []
+            @arbitrary_kw_args = false
+          end
         end
 
         self

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -26,10 +26,8 @@ module RSpec
         end
       end
 
-      def valid_non_kw_args?(positional_arg_count, optional_max_arg_count=nil)
+      def valid_non_kw_args?(positional_arg_count, optional_max_arg_count=positional_arg_count)
         return true if positional_arg_count.nil?
-
-        optional_max_arg_count ||= positional_arg_count
 
         min_non_kw_args <= positional_arg_count &&
           optional_max_arg_count <= max_non_kw_args

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -86,23 +86,24 @@ module RSpec
               expect(validate_expectation :unlimited_args).to eq(false)
             end
 
-            it 'does not match keywords' do
-              if RubyFeatures.kw_args_supported?
+            if RubyFeatures.kw_args_supported?
+              it 'does not match keywords' do
                 expect(validate_expectation :optional_keyword).to eq(false)
                 expect(validate_expectation 2, :optional_keyword).to eq(false)
-              else
-                expect(validate_expectation :optional_keyword).to eq(true)
-                expect(validate_expectation 2, :optional_keyword).to eq(true)
               end
-            end
 
-            if RubyFeatures.kw_args_supported?
               it 'does not match arbitrary keywords' do
                 expect(validate_expectation :arbitrary_kw_args).to eq(false)
               end
             else
+              it 'ignores keyword expectations' do
+                expect(validate_expectation :optional_keyword).to eq(false)
+                expect(validate_expectation 2, :optional_keyword).to eq(true)
+              end
+
               it 'ignores arbitrary keyword expectations' do
-                expect(validate_expectation :arbitrary_kw_args).to eq(true)
+                expect(validate_expectation :arbitrary_kw_args).to eq(false)
+                expect(validate_expectation 2, :arbitrary_kw_args).to eq(true)
               end
             end
           end
@@ -143,30 +144,32 @@ module RSpec
                 expect(validate_expectation 1, :unlimited_args).to eq(true)
               end
             else
-              it 'does not match unlimited arguments' do
+              it 'ignores unlimited arguments expectations' do
                 expect(validate_expectation :unlimited_args).to eq(false)
 
-                expect(validate_expectation 1, :unlimited_args).to eq(false)
-              end
-            end
-
-            it 'does not match keywords' do
-              if RubyFeatures.kw_args_supported?
-                expect(validate_expectation :optional_keyword).to eq(false)
-                expect(validate_expectation 2, :optional_keyword).to eq(false)
-              else
-                expect(validate_expectation :optional_keyword).to eq(true)
-                expect(validate_expectation 2, :optional_keyword).to eq(true)
+                expect(validate_expectation 1, :unlimited_args).to eq(true)
               end
             end
 
             if RubyFeatures.kw_args_supported?
+              it 'does not match keywords' do
+                expect(validate_expectation :optional_keyword).to eq(false)
+                expect(validate_expectation 2, :optional_keyword).to eq(false)
+              end
+
               it 'does not match arbitrary keywords' do
                 expect(validate_expectation :arbitrary_kw_args).to eq(false)
+                expect(validate_expectation 2, :arbitrary_kw_args).to eq(false)
               end
             else
+              it 'ignores keyword expectations' do
+                expect(validate_expectation :optional_keyword).to eq(false)
+                expect(validate_expectation 2, :optional_keyword).to eq(true)
+              end
+
               it 'ignores arbitrary keyword expectations' do
-                expect(validate_expectation :arbitrary_kw_args).to eq(true)
+                expect(validate_expectation :arbitrary_kw_args).to eq(false)
+                expect(validate_expectation 2, :arbitrary_kw_args).to eq(true)
               end
             end
           end
@@ -216,23 +219,26 @@ module RSpec
               expect(validate_expectation :unlimited_args).to eq(false)
             end
 
-            it 'does not match keywords' do
-              if RubyFeatures.kw_args_supported?
+            if RubyFeatures.kw_args_supported?
+              it 'does not match keywords' do
                 expect(validate_expectation :optional_keyword).to eq(false)
                 expect(validate_expectation 2, :optional_keyword).to eq(false)
-              else
-                expect(validate_expectation :optional_keyword).to eq(true)
-                expect(validate_expectation 2, :optional_keyword).to eq(true)
               end
-            end
 
-            if RubyFeatures.kw_args_supported?
               it 'does not match arbitrary keywords' do
                 expect(validate_expectation :arbitrary_kw_args).to eq(false)
               end
             else
+              it 'ignores keyword expectations' do
+                expect(validate_expectation :optional_keyword).to eq(false)
+
+                expect(validate_expectation 2, :optional_keyword).to eq(true)
+              end
+
               it 'ignores arbitrary keyword expectations' do
-                expect(validate_expectation :arbitrary_kw_args).to eq(true)
+                expect(validate_expectation :arbitrary_kw_args).to eq(false)
+
+                expect(validate_expectation 2, :arbitrary_kw_args).to eq(true)
               end
             end
           end


### PR DESCRIPTION
Supports https://github.com/rspec/rspec-expectations/issues/846.

Allows `MethodSignatureVerifier` to verify:
- Heterogenous min and max arguments counts (e.g. functions with optional arguments).
- Optional and/or required keyword arguments if supported by Ruby runtime.
- Splatted arguments and/or keyword arguments.

For an example of use, see https://github.com/rspec/rspec-expectations/compare/master...sleepingkingstudios:respond_to-keyword-arguments?expand=1