### PR TITLE
Ripper is not available on Rubinius

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -68,6 +68,8 @@ module RSpec
 
       ripper_requirements = [ComparableVersion.new(RUBY_VERSION) >= '1.9.2']
 
+      ripper_requirements.push(false) if Ruby.rbx?
+
       if Ruby.jruby?
         ripper_requirements.push(ComparableVersion.new(JRUBY_VERSION) >= '1.7.5')
         # Ripper on JRuby 9.0.0.0.rc1 or later reports wrong line number.


### PR DESCRIPTION
Since the release of RSpec 3.4, the Rubinius builds for the mysql2 gem began failing: https://travis-ci.org/brianmario/mysql2/jobs/91757782

The changelog for RSpec 3.4.0 says that Ripper is only used when available (https://github.com/rspec/rspec-core/commit/eedf9a9243aa520ba61a683b031836545fbe35c5), however the rspec-support implementation of ripper_supported? fails to mark Rubinius as unsupported.

Rubinius does not plan to implement Ripper: https://github.com/rubinius/rubinius/issues/2377
https://github.com/rubinius/rubinius/blob/master/README.md#the-ruby-programming-language