### PR TITLE
Truncate ObjectFormatter.format's output (#252)

### DIFF
--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -2,15 +2,41 @@ module RSpec
   module Support
     # Provide additional output details beyond what `inspect` provides when
     # printing Time, DateTime, or BigDecimal
-    module ObjectFormatter
-      # @api private
+    # @api private
+    class ObjectFormatter
+      attr_accessor :max_formatted_output_length
+
+      def initialize(max_formatted_output_length=200)
+        @max_formatted_output_length = max_formatted_output_length
+      end
+
+      # Methods are deferred to a default instance of the class to maintain the interface
+      # For example, calling ObjectFormatter.format is still possible
+      @default_instance = new(200)
+
+      ELLIPSIS = "..."
+
+      def format(object)
+        if max_formatted_output_length.nil?
+          return prepare_for_inspection(object).inspect
+        else
+          formatted_object = prepare_for_inspection(object).inspect
+          if formatted_object.length < max_formatted_output_length
+            return formatted_object
+          else
+            beginning = formatted_object[0 .. max_formatted_output_length / 2]
+            ending = formatted_object[-max_formatted_output_length / 2 ..-1]
+            return beginning + ELLIPSIS + ending
+          end
+        end
+      end
+
       def self.format(object)
-        prepare_for_inspection(object).inspect
+        @default_instance.format(object)
       end
 
       # rubocop:disable MethodLength
 
-      # @private
       # Prepares the provided object to be formatted by wrapping it as needed
       # in something that, when `inspect` is called on it, will produce the
       # desired output.
@@ -20,7 +46,7 @@ module RSpec
       # with custom items that have `inspect` defined to return the desired output
       # for that item. Then we can just use `Array#inspect` or `Hash#inspect` to
       # format the entire thing.
-      def self.prepare_for_inspection(object)
+      def prepare_for_inspection(object)
         case object
         when Array
           return object.map { |o| prepare_for_inspection(o) }
@@ -44,33 +70,41 @@ module RSpec
       end
       # rubocop:enable MethodLength
 
-      # @private
-      def self.prepare_hash(input)
+      def self.prepare_for_inspection(object)
+        @default_instance.prepare_for_inspection(object)
+      end
+
+      def prepare_hash(input)
         input.inject({}) do |hash, (k, v)|
           hash[prepare_for_inspection(k)] = prepare_for_inspection(v)
           hash
         end
       end
 
+      def self.prepare_hash(input)
+        @default_instance.prepare_hash(input)
+      end
+
       TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
       if Time.method_defined?(:nsec)
-        # @private
-        def self.format_time(time)
+        def format_time(time)
           time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
         end
       else # for 1.8.7
-        # @private
-        def self.format_time(time)
+        def format_time(time)
           time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
         end
+      end
+
+      def self.format_time(time)
+        @default_instance.format_time(time)
       end
 
       DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
       # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
       # defined use a custom format string that includes more time precision.
-      # @private
-      def self.format_date_time(date_time)
+      def format_date_time(date_time)
         if defined?(ActiveSupport)
           date_time.strftime(DATE_TIME_FORMAT)
         else
@@ -78,7 +112,10 @@ module RSpec
         end
       end
 
-      # @private
+      def self.format_date_time(date_time)
+        @default_instance.format_date_time(date_time)
+      end
+
       InspectableItem = Struct.new(:inspection) do
         def inspect
           inspection
@@ -89,7 +126,6 @@ module RSpec
         end
       end
 
-      # @private
       DelegatingInspector = Struct.new(:object) do
         def inspect
           if defined?(::Delegator) && ::Delegator === object

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -158,6 +158,25 @@ module RSpec
             matcher_without_a_description.inspect)
         end
       end
+
+      context 'with truncation enabled' do
+        it 'produces an output of limited length' do
+          formatter = ObjectFormatter.new(10)
+          expect(formatter.format('Test String Of A Longer Length')).to eq('"Test ...ngth"')
+        end
+
+        it 'does not truncate shorter strings' do
+          formatter = ObjectFormatter.new(10)
+          expect(formatter.format('Testing')).to eq('"Testing"')
+        end
+      end
+
+      context 'with truncation disabled' do
+        it 'does not limit the output length' do
+          formatter = ObjectFormatter.new(nil)
+          expect(formatter.format('Test String Of A Longer Length')).to eq('"Test String Of A Longer Length"')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Initial changes and a simple test for
https://github.com/rspec/rspec-support/issues/252