### PR TITLE
Fix StdErrSplitter spec on MRI 2.3

### DIFF
--- a/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -22,7 +22,11 @@ describe 'RSpec::Support::StdErrSplitter' do
   end
 
   it 'conforms to the stderr interface' do
-    stderr_methods = stderr.methods
+    # There some methods that appear in the list of the #methods but actually not implemented:
+    #
+    #     $stderr.pressed?
+    #     NotImplementedError: pressed?() function is unimplemented on this machine
+    stderr_methods = stderr.methods.select { |method| stderr.respond_to?(method) }
 
     # On 2.2, there's a weird issue where stderr sometimes responds to `birthtime` and sometimes doesn't...
     stderr_methods -= [:birthtime] if RUBY_VERSION =~ /^2\.2/


### PR DESCRIPTION
There some new IO methods in MRI 2.3, but they are not implemented on `$stderr`.

```
Failures:

  1) RSpec::Support::StdErrSplitter conforms to the stderr interface
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected #<RSpec::Support::StdErrSplitter:0x007f84eb9abba0 @orig_stderr=#<IO:<STDERR>>, @output_tracker=#<StringIO:0x007f84eb9abb78>> to respond to :goto, :cursor, :cursor=, :pressed?
     # ./spec/rspec/support/spec/stderr_splitter_spec.rb:33:in `block (2 levels) in <top (required)>'
     # ./spec/rspec/support/spec/stderr_splitter_spec.rb:19:in `block (2 levels) in <top (required)>'
```

```ruby
[1] pry(main)> $stderr.methods.include?(:pressed?)
=> true
[2] pry(main)> $stderr.respond_to?(:pressed?)
=> false
[3] pry(main)> $stderr.pressed?
NotImplementedError: pressed?() function is unimplemented on this machine
from (pry):3:in `pressed?'
```