### PR TITLE
Fix JRuby bug with encoded string splitting

### DIFF
--- a/lib/rspec/support/encoded_string.rb
+++ b/lib/rspec/support/encoded_string.rb
@@ -47,8 +47,18 @@ module RSpec
         @string << matching_encoding(string)
       end
 
-      def split(regex_or_string)
-        @string.split(matching_encoding(regex_or_string))
+      if Ruby.jruby?
+        def split(regex_or_string)
+          @string.split(matching_encoding(regex_or_string))
+        rescue ArgumentError
+          # JRuby raises an ArgumentError when splitting a source string that
+          # contains invalid bytes.
+          remove_invalid_bytes(@string).split regex_or_string
+        end
+      else
+        def split(regex_or_string)
+          @string.split(matching_encoding(regex_or_string))
+        end
       end
 
       def to_s

--- a/spec/rspec/support/encoded_string_spec.rb
+++ b/spec/rspec/support/encoded_string_spec.rb
@@ -195,6 +195,16 @@ module RSpec::Support
               a_string_identical_to(exp2).with_same_encoding
             ]
           end
+
+          it 'handles invalidly encoded strings' do
+            source_string = "an\xAE\nother".force_encoding('US-ASCII')
+            expect(
+              build_encoded_string(source_string, utf8_encoding).split("\n")
+            ).to eq([
+              'an?',
+              'other'
+            ])
+          end
         end
 
         # see https://github.com/rspec/rspec-expectations/blob/f8a1232/spec/rspec/expectations/fail_with_spec.rb#L50


### PR DESCRIPTION
JRuby has a different behaviour when splitting strings to all the other Rubies