### PR TITLE
Handle non-immediate recursive structures in ObjectFormatter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ Bug Fixes:
   `#inspect` (such as `BasicObject`) does not cause `NoMethodError`.
   (Yuji Nakayama, #269)
 * Fix `ObjectFormatter` so that formatting recursive array or hash does not
-  cause `SystemStackError`. (Yuji Nakayama, #270)
+  cause `SystemStackError`. (Yuji Nakayama, #270, #272)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.4.1...v3.5.0.beta1)

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -253,6 +253,53 @@ module RSpec
         end
       end
 
+      context 'with a non-immediate recursive array' do
+        subject(:output) do
+          ObjectFormatter.format(input)
+        end
+
+        let(:input) do
+          array = []
+          array[0] = { :recursive_array => array }
+          array
+        end
+
+        it 'formats the recursive element as [...]' do
+          expect(output).to eq('[{:recursive_array=>[...]}]')
+        end
+      end
+
+      context 'with a non-immediate recursive hash' do
+        subject(:output) do
+          ObjectFormatter.format(input)
+        end
+
+        let(:input) do
+          hash = {}
+          hash[:array] = [:next_is_recursive_hash, hash]
+          hash
+        end
+
+        it 'formats the recursive element as {...}' do
+          expect(output).to eq('{:array=>[:next_is_recursive_hash, {...}]}')
+        end
+      end
+
+      context 'with an array including a same collection object multiple times' do
+        subject(:output) do
+          ObjectFormatter.format(input)
+        end
+
+        let(:input) do
+          hash = { :key => 'value' }
+          [hash, hash]
+        end
+
+        it 'does not omit them' do
+          expect(output).to eq('[{:key=>"value"}, {:key=>"value"}]')
+        end
+      end
+
       context 'with truncation enabled' do
         it 'produces an output of limited length' do
           formatter = ObjectFormatter.new(10)


### PR DESCRIPTION
Pointed out in: https://github.com/rspec/rspec-support/pull/270#issuecomment-199298121