### PR TITLE
fix sometimes no HOME path set

### DIFF
--- a/rspec-support.gemspec
+++ b/rspec-support.gemspec
@@ -19,7 +19,12 @@ Gem::Specification.new do |spec|
   spec.rdoc_options  = ["--charset=UTF-8"]
   spec.require_paths = ["lib"]
 
-  private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
+
+  private_key = ""
+  begin
+    private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
+  rescue ArgumentError => e
+  end
   if File.exist?(private_key)
     spec.signing_key = private_key
     spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]


### PR DESCRIPTION
I received an error when deploying the latest master to AWS Beanstalk. In the deployment process no `HOME` ENV variable was set.

```
There was a ArgumentError while loading rspec-support.gemspec:
couldn't find HOME environment -- expanding `~' from
/opt/rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rspec-support-d8666d5fc14a/rspec-support.gemspec:22:in
`expand_path'.
```

This pull request fixes that. IF you have feedback, please let me know.
