### PR TITLE
Ignore bundler warnings on windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.5.0.beta1...master)
 
+Enhancements:
+* Improve `MethodSignature` to better support keyword arguments. (#250, Rob Smith).
+
 Bug Fixes:
 
 * Fix `ObjectFormatter` so that formatting objects that don't respond to

--- a/lib/rspec/support/spec/library_wide_checks.rb
+++ b/lib/rspec/support/spec/library_wide_checks.rb
@@ -68,9 +68,7 @@ RSpec.shared_examples_for "library wide checks" do |lib, options|
       run_ruby_with_current_load_path(command, *options)
     end
 
-    # Ignore bundler warning.
-    stderr = stderr.split("\n").reject { |l| l =~ %r{bundler/source/rubygems} }.join("\n")
-    [stdout, stderr, status.exitstatus]
+    [stdout, strip_known_warnings(stderr), status.exitstatus]
   end
 
   define_method :load_all_lib_files do

--- a/lib/rspec/support/spec/shell_out.rb
+++ b/lib/rspec/support/spec/shell_out.rb
@@ -53,6 +53,17 @@ module RSpec
         end
       end
 
+      def strip_known_warnings(input)
+        input.split("\n").reject do |l|
+          # Ignore bundler warning.
+          l =~ %r{bundler/source/rubygems} ||
+          # Ignore bundler + rubygems warning.
+          l =~ %r{site_ruby/\d\.\d\.\d/rubygems} ||
+          # This is required for windows for some reason
+          l =~ %r{lib/bundler/rubygems}
+        end.join("\n")
+      end
+
     private
 
       if Ruby.jruby?

--- a/spec/rspec/support/spec/shell_out_spec.rb
+++ b/spec/rspec/support/spec/shell_out_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RSpec::Support::ShellOut, :slow do
   it 'passes along the provided ruby flags' do
     out, err, status = run_ruby_with_current_load_path('puts "version"', '-v')
     expect(out).to include('version', RUBY_DESCRIPTION)
-    expect(err).to eq('')
+    expect(strip_known_warnings err).to eq('')
     expect(status.exitstatus).to eq(0)
   end
 
@@ -41,7 +41,7 @@ RSpec.describe RSpec::Support::ShellOut, :slow do
     with_env 'RUBY_GC_HEAP_FREE_SLOTS' => '10001', 'RUBY_GC_MALLOC_LIMIT' => '16777217', 'RUBY_FREE_MIN' => '10001' do
       out, err, status = run_ruby_with_current_load_path('', '-w')
       expect(out).to eq('')
-      expect(err).to eq('')
+      expect(strip_known_warnings err).to eq('')
       expect(status.exitstatus).to eq(0)
     end
   end


### PR DESCRIPTION
Currently windows builds get broken by a bundler warning