### PR TITLE
Frozen string literals [experimental]

### DIFF
--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # @api private

--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec::Support.require_rspec_support "ruby_features"
 
 module RSpec

--- a/lib/rspec/support/comparable_version.rb
+++ b/lib/rspec/support/comparable_version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -182,19 +182,19 @@ module RSpec
         when Hash
           hash_to_string(object)
         when Array
-          PP.pp(ObjectFormatter.prepare_for_inspection(object), "")
+          PP.pp(ObjectFormatter.prepare_for_inspection(object), String.new)
         when String
           object =~ /\n/ ? object : object.inspect
         else
-          PP.pp(object, "")
+          PP.pp(object, String.new)
         end
       end
 
       def hash_to_string(hash)
         formatted_hash = ObjectFormatter.prepare_for_inspection(hash)
         formatted_hash.keys.sort_by { |k| k.to_s }.map do |key|
-          pp_key   = PP.singleline_pp(key, "")
-          pp_value = PP.singleline_pp(formatted_hash[key], "")
+          pp_key   = PP.singleline_pp(key, String.new)
+          pp_value = PP.singleline_pp(formatted_hash[key], String.new)
 
           "#{pp_key} => #{pp_value},"
         end.join("\n")

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'hunk_generator'
 RSpec::Support.require_rspec_support "object_formatter"

--- a/lib/rspec/support/directory_maker.rb
+++ b/lib/rspec/support/directory_maker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec::Support.require_rspec_support 'ruby_features'
 
 module RSpec

--- a/lib/rspec/support/encoded_string.rb
+++ b/lib/rspec/support/encoded_string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # Provides a means to fuzzy-match between two arbitrary objects.

--- a/lib/rspec/support/hunk_generator.rb
+++ b/lib/rspec/support/hunk_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'diff/lcs'
 require 'diff/lcs/hunk'
 

--- a/lib/rspec/support/matcher_definition.rb
+++ b/lib/rspec/support/matcher_definition.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/support'
 RSpec::Support.require_rspec_support "ruby_features"
 RSpec::Support.require_rspec_support "matcher_definition"

--- a/lib/rspec/support/mutex.rb
+++ b/lib/rspec/support/mutex.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # On 1.8.7, it's in the stdlib.

--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec::Support.require_rspec_support 'matcher_definition'
 
 module RSpec

--- a/lib/rspec/support/recursive_const_methods.rb
+++ b/lib/rspec/support/recursive_const_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # Provides recursive constant lookup methods useful for

--- a/lib/rspec/support/reentrant_mutex.rb
+++ b/lib/rspec/support/reentrant_mutex.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     # Allows a thread to lock out other threads from a critical section of code,

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rbconfig'
 RSpec::Support.require_rspec_support "comparable_version"
 

--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/support'
 require 'rspec/support/spec/in_sub_process'
 

--- a/lib/rspec/support/spec/deprecation_helpers.rb
+++ b/lib/rspec/support/spec/deprecation_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpecHelpers
   def expect_no_deprecation
     expect(RSpec.configuration.reporter).not_to receive(:deprecation)

--- a/lib/rspec/support/spec/formatting_support.rb
+++ b/lib/rspec/support/spec/formatting_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     module FormattingSupport

--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     module InSubProcess

--- a/lib/rspec/support/spec/library_wide_checks.rb
+++ b/lib/rspec/support/spec/library_wide_checks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/support/spec/shell_out'
 
 module RSpec

--- a/lib/rspec/support/spec/shell_out.rb
+++ b/lib/rspec/support/spec/shell_out.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'open3'
 require 'rake/file_utils'
 require 'shellwords'

--- a/lib/rspec/support/spec/stderr_splitter.rb
+++ b/lib/rspec/support/spec/stderr_splitter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'stringio'
 
 module RSpec

--- a/lib/rspec/support/spec/string_matcher.rb
+++ b/lib/rspec/support/spec/string_matcher.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/matchers'
 # Special matcher for comparing encoded strings so that
 # we don't run any expectation failures through the Differ,

--- a/lib/rspec/support/spec/with_isolated_directory.rb
+++ b/lib/rspec/support/spec/with_isolated_directory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'tmpdir'
 
 RSpec.shared_context "isolated directory" do

--- a/lib/rspec/support/spec/with_isolated_stderr.rb
+++ b/lib/rspec/support/spec/with_isolated_stderr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     module WithIsolatedStdErr

--- a/lib/rspec/support/version.rb
+++ b/lib/rspec/support/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RSpec
   module Support
     module Version

--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/support'
 RSpec::Support.require_rspec_support "caller_filter"
 

--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -29,8 +29,8 @@ module RSpec
       # Used internally to print longer warnings
       def warn_with(message, options={})
         call_site = options.fetch(:call_site) { CallerFilter.first_non_rspec_line }
-        message << " Use #{options[:replacement]} instead." if options[:replacement]
-        message << " Called from #{call_site}." if call_site
+        message += " Use #{options[:replacement]} instead." if options[:replacement]
+        message += " Called from #{call_site}." if call_site
         Support.warning_notifier.call message
       end
     end


### PR DESCRIPTION
Attempting to resolve whether or not Ruby 3+ frozen string literals represent a performance regression in 2.3. Related to rspec/rspec-core#2264

My manual testing with `time rspec` shows the original code took around 2.35s and the frozen literal code took around 2.35 seconds (it was fairly consistent over multiple runs). Hardly scientific, but good enough for me.

Requires [rspec/rspec-core](../../rspec-core) to also use the `frozen-string-literals` branch to run.
