### PR TITLE
Trailing newlines are calculated and represented in differ output. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
-%w[rspec rspec-core rspec-expectations rspec-mocks].each do |lib|
+#%w[rspec rspec-core rspec-expectations rspec-mocks].each do |lib|
+%w[rspec rspec-core rspec-mocks].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
@@ -12,6 +13,9 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
     gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
+
+gem 'rspec-expectations', git: 'git://github.com/chaeokay/rspec-expectations.git',
+                          branch: 'chaeokay/display_trailing_newlines'
 
 ### dep for ci/coverage
 gem 'simplecov', '~> 0.8'

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -187,6 +187,8 @@ module RSpec
           PP.pp(ObjectFormatter.prepare_for_inspection(object), "")
         when String
           object =~ /\n/ ? object : object.inspect
+        when Regexp
+          PP.pp(object, "").chomp
         else
           PP.pp(object, "")
         end

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -46,11 +46,7 @@ module RSpec
           end
         end
 
-        if hunks.last
-          last_hunk_diff = hunks.last.diff(format_type).to_s.strip
-          finalize_output(output, last_hunk_diff)
-        end
-
+        finalize_output(output, final_line(hunks.last)) if hunks.last
         color_diff output
       rescue Encoding::CompatibilityError
         handle_encoding_errors(actual, expected)
@@ -117,6 +113,12 @@ module RSpec
 
       def build_hunks(actual, expected)
         HunkGenerator.new(actual, expected).hunks
+      end
+
+      def final_line(last_hunk)
+        output_message = last_hunk.diff(format_type).to_s.strip
+        # Checks last char of string for + or -, appends message on match
+        output_message.gsub(/(?<=[+-]$)\z/, "\\ No newline at end of input")
       end
 
       def finalize_output(output, final_line)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -46,7 +46,10 @@ module RSpec
           end
         end
 
-        finalize_output(output, hunks.last.diff(format_type).to_s) if hunks.last
+        if hunks.last
+          last_hunk_diff = hunks.last.diff(format_type).to_s.strip
+          finalize_output(output, last_hunk_diff)
+        end
 
         color_diff output
       rescue Encoding::CompatibilityError

--- a/lib/rspec/support/hunk_generator.rb
+++ b/lib/rspec/support/hunk_generator.rb
@@ -24,11 +24,11 @@ module RSpec
       end
 
       def expected_lines
-        @expected.split("\n").map! { |e| e.chomp }
+        @expected.to_s.split("\n", -1).map! { |e| e.chomp }
       end
 
       def actual_lines
-        @actual.split("\n").map! { |e| e.chomp }
+        @actual.to_s.split("\n", -1).map! { |e| e.chomp }
       end
 
       def build_hunk(piece)

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -25,7 +25,7 @@ module RSpec
  this
  is
  soo
-@@ -9,6 +9,5 @@
+@@ -9,7 +9,6 @@
  equal
  insert
  a
@@ -52,7 +52,7 @@ EOD
             | this
             | is
             | soo
-            |@@ -9,6 +9,5 @@
+            |@@ -9,7 +9,6 @@
             | equal
             | insert
             | a
@@ -106,7 +106,7 @@ EOD
           it 'handles differently encoded strings that are compatible' do
             expected = "abc\n".encode('us-ascii')
             actual   = "강인철\n".encode('UTF-8')
-            expected_diff = "\n@@ -1,2 +1,2 @@\n-abc\n+강인철\n"
+            expected_diff = "\n@@ -1,3 +1,3 @@\n-abc\n+강인철\n"
             diff = differ.diff(actual, expected)
             expect(diff).to be_diffed_as(expected_diff)
           end
@@ -114,7 +114,7 @@ EOD
           it 'uses the default external encoding when the two strings have incompatible encodings', :failing_on_appveyor do
             expected = "Tu avec carte {count} item has\n"
             actual   = "Tu avec carté {count} itém has\n".encode('UTF-16LE')
-            expected_diff = "\n@@ -1,2 +1,2 @@\n-Tu avec carte {count} item has\n+Tu avec carté {count} itém has\n"
+            expected_diff = "\n@@ -1,3 +1,3 @@\n-Tu avec carte {count} item has\n+Tu avec carté {count} itém has\n"
 
             diff = differ.diff(actual, expected)
             expect(diff).to be_diffed_as(expected_diff)
@@ -154,7 +154,7 @@ EOD
 
           expected_diff = <<'EOD'
 
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  <Animal
    name=bob,
 -  species=tortoise
@@ -173,7 +173,7 @@ EOD
           expected_diff = <<'EOD'
 
 
-@@ -5,7 +5,7 @@
+@@ -5,8 +5,8 @@
   :metasyntactic,
   "variable",
   :delta,
@@ -202,7 +202,7 @@ EOD
 
           expected_diff = <<-EOD
 
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
 -[]
 +[<BrokenObject>]
 EOD
@@ -296,7 +296,7 @@ EOD
 
         it "outputs unified diff message of two arrays with Time object keys" do
           expected_diff = %Q{
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
 -[#{formatted_time}, "b"]
 +[#{formatted_time}, "c"]
 }
@@ -307,7 +307,7 @@ EOD
 
         it "outputs unified diff message of two arrays with hashes inside them" do
           expected_diff = %Q{
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
 -[{"b"=>#{formatted_time}}, "c"]
 +[{"a"=>#{formatted_time}}, "c"]
 }
@@ -402,7 +402,7 @@ EOD
 
             expected_diff = dedent(<<-EOS)
               |
-              |@@ -1,2 +1,2 @@
+              |@@ -1,3 +1,3 @@
               |-[#<SimpleDelegator(#{object.inspect})>]
               |+[#{object.inspect}]
               |
@@ -441,7 +441,7 @@ EOD
           it "outputs colored diffs" do
             expected = "foo bar baz\n"
             actual = "foo bang baz\n"
-            expected_diff = "\e[0m\n\e[0m\e[34m@@ -1,2 +1,2 @@\n\e[0m\e[31m-foo bang baz\n\e[0m\e[32m+foo bar baz\n\e[0m"
+            expected_diff = "\e[0m\n\e[0m\e[34m@@ -1,3 +1,3 @@\n\e[0m\e[31m-foo bang baz\n\e[0m\e[32m+foo bar baz\n\e[0m"
 
             diff = differ.diff(expected,actual)
             expect(diff).to be_diffed_as(expected_diff)


### PR DESCRIPTION
This is pretty much what @phiggins wrote in #71 :) but is up-to-date with master and rspec-expectations. 

See commit message in 3a0af727880692a20e64d0e9 and [rspec-expectations PR #290](https://github.com/rspec/rspec-expectations/pull/929)

@coralineada gave me the courage to dive in, and @alindeman let me borrow his eyes over coffee. I'm open to feedback, continued help, and working on next steps whatever they may be!

Fixes #70
