### PR TITLE
CR should be escaped when displaying difference.

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -97,7 +97,7 @@ module RSpec
           if Array === entry
             entry.inspect
           else
-            entry.to_s.gsub("\n", "\\n")
+            entry.to_s.gsub("\n", "\\n").gsub("\r", "\\r")
           end
         end
       end


### PR DESCRIPTION
When displaying difference, CR(\r) in String should be escaped.

foo_spec.rb:

``` ruby
describe 'foo' do
  it 'bar' do
    expect(["ABC\r\n1234567890"]).to eq ["abc\r\n1234567890"]
  end
end
```

Run rpsec:

```
% rspec foo_spec.rb
F

Failures:

  1) foo bar
     Failure/Error: expect(["ABC\r\n1234567890"]).to eq ["abc\r\n1234567890"]

       expected: ["abc\r\n1234567890"]
            got: ["ABC\r\n1234567890"]

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
\n1234567890
\n1234567890

     # ./foo_spec.rb:3:in `block (2 levels) in <top (required)>'

Finished in 0.00843 seconds (files took 0.06066 seconds to load)
1 example, 1 failure
```

rspec shows "\n1234567890". but it should be "abc\r\n1234567890" and "ABC\r\n1234567890".
