### PR TITLE
Bugfix - Remove partial ANSI colour codes when truncating object.inspect

### DIFF
--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -37,8 +37,8 @@ module RSpec
           if formatted_object.length < max_formatted_output_length
             return formatted_object
           else
-            beginning = formatted_object[0 .. max_formatted_output_length / 2]
-            ending = formatted_object[-max_formatted_output_length / 2 ..-1]
+            beginning = truncate_string formatted_object, 0, max_formatted_output_length / 2
+            ending = truncate_string formatted_object, -max_formatted_output_length / 2, -1
             return beginning + ELLIPSIS + ending
           end
         end
@@ -244,6 +244,20 @@ module RSpec
         DelegatorInspector,
         InspectableObjectInspector
       ]
+
+    private
+
+      # Returns the substring defined by the start_index and end_index
+      # If the string ends with a partial ANSI code code then that
+      # will be removed as printing partial ANSI
+      # codes to the terminal can lead to corruption
+      def truncate_string(str, start_index, end_index)
+        cut_str = str[start_index..end_index]
+
+        # ANSI color codes are like: \e[33m so anything with \e[ and a
+        # number without a 'm' is an incomplete color code
+        cut_str.sub(/\e\[\d+$/, '')
+      end
     end
   end
 end

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -310,6 +310,18 @@ module RSpec
           formatter = ObjectFormatter.new(10)
           expect(formatter.format('Testing')).to eq('"Testing"')
         end
+
+        context 'with ANSI escape codes that fall on the truncate split' do
+          it 'removes that escape code so terminals do not get corrupted print a partial escape code' do
+            formatter = ObjectFormatter.new(38)
+            object = Class.new do
+              def inspect
+                "#<\e[33mClass\e[0m \e[36mname: \e[0m\"foobars\" \e[36mcount: \e[0m42>"
+              end
+            end.new
+            expect(formatter.format(object)).to eq("#<\e[33mClass\e[0m ...\e[36mcount: \e[0m42>")
+          end
+        end
       end
 
       context 'with truncation disabled' do


### PR DESCRIPTION
When truncating an object using `ObjectFormatter.format` that exceeds the max_formatted_output_length remove any partial ANSI color codes.

This fixes an edge case where partial ANSI color codes eg `\e[3` is printed to the terminal which corrupts the output.

eg calling object.inspect = "#<\e[33mClass\e[0m \e[36mname: \e[0m\"foobars\" \e[36mcount: \e[0m42>"
If this was truncated at the 19th char then the result would be: "#<\e[33mClass\e[0m \e[3"
(which results in an invalid escape code).
This commit will remove the partial ANSI code so the result is now: "#<\e[33mClass\e[0m "

To demonstrate the problem here is a screenshot of an example spec running rspec-support 3.4 with good output:
<img width="1898" alt="screen shot 2016-08-26 at 15 44 13" src="https://cloud.githubusercontent.com/assets/722405/18009411/04f71f1a-6ba4-11e6-9754-515cc2999fb9.png">

And here is the same spec running rspec-support 3.5 with a bad ANSI code corrupting output:
(The output in the `expected [] to include...` line contains the bad ANSI code which seems to reset the terminal to the top so the output overwrites)
<img width="1897" alt="screen shot 2016-08-26 at 15 42 47" src="https://cloud.githubusercontent.com/assets/722405/18009440/2bca7b5a-6ba4-11e6-8bc0-f01acd4e523d.png">
