### PR TITLE
Spelling fix in RSpec comment

### DIFF
--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -69,7 +69,7 @@ module RSpec
     end
 
     describe RubyFeatures do
-      specify "#module_refinedment_supported? reflects refinement support" do
+      specify "#module_refinement_supported? reflects refinement support" do
         if Ruby.mri? && RUBY_VERSION >= '2.1.0'
           expect(RubyFeatures.module_refinement_supported?).to eq true
         end


### PR DESCRIPTION
This PR corrects the name of a RSpec context to match its content.