### PR TITLE
Define `supports_qualified_constant_toplevel_lookup?`

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -90,6 +90,23 @@ module RSpec
         end
       end
 
+      begin
+        verbose_was = $VERBOSE
+        $VERBOSE = nil
+
+        _ = String::Hash
+
+        def supports_qualified_constant_toplevel_lookup?
+          true
+        end
+      rescue NameError
+        def supports_qualified_constant_toplevel_lookup?
+          false
+        end
+      ensure
+        $VERBOSE = verbose_was
+      end
+
       if Ruby.mri?
         def kw_args_supported?
           RUBY_VERSION >= '2.0.0'

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -91,6 +91,10 @@ module RSpec
         RubyFeatures.supports_rebinding_module_methods?
       end
 
+      specify "#supports_qualified_constant_toplevel_lookup? exists" do
+        RubyFeatures.supports_qualified_constant_toplevel_lookup?
+      end
+
       specify "#caller_locations_supported? exists" do
         RubyFeatures.caller_locations_supported?
         if Ruby.mri?


### PR DESCRIPTION
In Ruby 2.5, top-level constant look-up through a qualified constant
is not permitted, so we have to check qualified constants top level
look up is supported.

see: https://github.com/ruby/ruby/commit/44a2576f798b07139adde2d279e48fdbe71a0148