### PR TITLE
Reflect Ripper support in the latest JRuby in #ripper_supported

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0.beta2...master)
+
+Enhancements:
+
+* Reflect Ripper support in the latest JRuby in `RubyFeatures#ripper_supported`
+  so that rspec-core on JRuby 9.1.0.0 or later can benefit from the multiline
+  failure snippet extraction. (Yuji Nakayama, #313)
+
 ### 3.6.0.beta2 / 2016-12-12
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0.beta1...v3.6.0.beta2)
 

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -28,6 +28,10 @@ module RSpec
         RUBY_PLATFORM == 'java'
       end
 
+      def jruby_version
+        @jruby_version ||= ComparableVersion.new(JRUBY_VERSION)
+      end
+
       def jruby_9000?
         jruby? && JRUBY_VERSION >= '9.0.0.0'
       end
@@ -75,9 +79,9 @@ module RSpec
       ripper_requirements.push(false) if Ruby.rbx?
 
       if Ruby.jruby?
-        ripper_requirements.push(ComparableVersion.new(JRUBY_VERSION) >= '1.7.5')
-        # Ripper on JRuby 9.0.0.0.rc1 or later reports wrong line number.
-        ripper_requirements.push(ComparableVersion.new(JRUBY_VERSION) < '9.0.0.0.rc1')
+        ripper_requirements.push(Ruby.jruby_version >= '1.7.5')
+        # Ripper on JRuby 9.0.0.0.rc1 - 9.0.5.0 reports wrong line number.
+        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.0.5.0'))
       end
 
       if ripper_requirements.all?

--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -3,40 +3,57 @@ module RSpec
     module InSubProcess
       if Process.respond_to?(:fork) && !(Ruby.jruby? && RUBY_VERSION == '1.8.7')
 
+        UnmarshableObject = Struct.new(:error)
+
         # Useful as a way to isolate a global change to a subprocess.
 
         # rubocop:disable MethodLength
         def in_sub_process(prevent_warnings=true)
-          readme, writeme = IO.pipe
+          exception_reader, exception_writer = IO.pipe
+          result_reader, result_writer = IO.pipe
 
           pid = Process.fork do
-            exception = nil
             warning_preventer = $stderr = RSpec::Support::StdErrSplitter.new($stderr)
 
             begin
-              yield
+              result = yield
               warning_preventer.verify_no_warnings! if prevent_warnings
-            rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
-              exception = e
+              # rubocop:disable Lint/HandleExceptions
+            rescue Support::AllExceptionsExceptOnesWeMustNotRescue => exception
+              # rubocop:enable Lint/HandleExceptions
             end
 
-            writeme.write Marshal.dump(exception)
+            exception_writer.write marshal_dump_with_unmarshable_object_handling(exception)
+            exception_reader.close
+            exception_writer.close
 
-            readme.close
-            writeme.close
+            result_writer.write marshal_dump_with_unmarshable_object_handling(result)
+            result_reader.close
+            result_writer.close
+
             exit! # prevent at_exit hooks from running (e.g. minitest)
           end
 
-          writeme.close
+          exception_writer.close
+          result_writer.close
           Process.waitpid(pid)
 
-          exception = Marshal.load(readme.read)
-          readme.close
-
+          exception = Marshal.load(exception_reader.read)
+          exception_reader.close
           raise exception if exception
+
+          result = Marshal.load(result_reader.read)
+          result_reader.close
+          result
         end
         # rubocop:enable MethodLength
         alias :in_sub_process_if_possible :in_sub_process
+
+        def marshal_dump_with_unmarshable_object_handling(object)
+          Marshal.dump(object)
+        rescue TypeError => error
+          Marshal.dump(UnmarshableObject.new(error))
+        end
       else
         def in_sub_process(*)
           skip "This spec requires forking to work properly, " \

--- a/spec/rspec/support/spec/in_sub_process_spec.rb
+++ b/spec/rspec/support/spec/in_sub_process_spec.rb
@@ -12,6 +12,14 @@ describe 'isolating code to a sub process' do
 
   if Process.respond_to?(:fork) && !(RUBY_PLATFORM == 'java' && RUBY_VERSION == '1.8.7')
 
+    it 'returns the result of sub process' do
+      expect(in_sub_process { :foo }).to eq(:foo)
+    end
+
+    it 'returns a UnmarshableObject if the result of sub process cannot be marshaled' do
+      expect(in_sub_process { proc {} }).to be_a(RSpec::Support::InSubProcess::UnmarshableObject)
+    end
+
     it 'captures and reraises errors to the main process' do
       expect {
         in_sub_process { raise "An Internal Error" }


### PR DESCRIPTION
... so that rspec-core on JRuby 9.1.0.0 or later can benefit from the multiline failure snippet extraction.

I've checked if the spec passes on all JRuby 9.x.x.x.

https://travis-ci.org/rspec/rspec-support/builds/222465272

<img width="398" alt="screen shot 2017-04-16 at 9 42 51" src="https://cloud.githubusercontent.com/assets/83656/25067799/3b238ef6-2289-11e7-8fd8-353fb8a9710c.png">
