### PR TITLE
Mark Ripper on the latest JRuby as broken

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,6 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0.beta2...master)
 
-Enhancements:
-
-* Reflect Ripper support in the latest JRuby in `RubyFeatures#ripper_supported`
-  so that rspec-core on JRuby 9.1.0.0 or later can benefit from the multiline
-  failure snippet extraction. (Yuji Nakayama, #313)
-
 ### 3.6.0.beta2 / 2016-12-12
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0.beta1...v3.6.0.beta2)
 

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -80,8 +80,9 @@ module RSpec
 
       if Ruby.jruby?
         ripper_requirements.push(Ruby.jruby_version >= '1.7.5')
-        # Ripper on JRuby 9.0.0.0.rc1 - 9.0.5.0 reports wrong line number.
-        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.0.5.0'))
+        # Ripper on JRuby 9.0.0.0.rc1 or later reports wrong line number
+        # or cannot parse source including `:if`.
+        ripper_requirements.push(Ruby.jruby_version < '9.0.0.0.rc1')
       end
 
       if ripper_requirements.all?

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -111,6 +111,12 @@ module RSpec
         end
 
         def ripper_works_correctly?
+          ripper_reports_correct_line_number? &&
+            ripper_can_parse_source_including_keywordish_symbol?
+        end
+
+        # https://github.com/jruby/jruby/issues/3386
+        def ripper_reports_correct_line_number?
           in_sub_process_if_possible do
             require 'ripper'
             tokens = ::Ripper.lex('foo')
@@ -118,6 +124,15 @@ module RSpec
             location = token.first
             line_number = location.first
             line_number == 1
+          end
+        end
+
+        # https://github.com/jruby/jruby/issues/4562
+        def ripper_can_parse_source_including_keywordish_symbol?
+          in_sub_process_if_possible do
+            require 'ripper'
+            sexp = ::Ripper.sexp(':if')
+            !sexp.nil?
           end
         end
 


### PR DESCRIPTION
It turned out that Ripper on the latest JRuby still had [another bug](https://github.com/jruby/jruby/issues/4562).

This fixes CI failure reported in https://github.com/rspec/rspec-support/pull/313#issuecomment-294385384.
