### PR TITLE
Explicitly get a module name using `name`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0...master)
+
+Bug Fixes:
+
+* Fix recursive const support to not blow up when given buggy classes
+  that raise odd errors from `#to_str`. (Myron Marston, #317)
+
 ### 3.6.0 / 2017-05-04
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.6.0.beta2...3.6.0)
 

--- a/lib/rspec/support/recursive_const_methods.rb
+++ b/lib/rspec/support/recursive_const_methods.rb
@@ -64,7 +64,7 @@ module RSpec
         parts.inject([Object, '']) do |(mod, full_name), name|
           yield(full_name, name) if block_given? && !(Module === mod)
           return false unless const_defined_on?(mod, name)
-          [get_const_defined_on(mod, name), [mod, name].join('::')]
+          [get_const_defined_on(mod, name), [mod.name, name].join('::')]
         end
       end
 

--- a/spec/rspec/support/recursive_const_methods_spec.rb
+++ b/spec/rspec/support/recursive_const_methods_spec.rb
@@ -31,6 +31,13 @@ module RSpec
         it 'does not find constants in ancestors' do
           expect(recursive_const_defined?('::RSpec::Support::Foo::Bar::UNDETECTED')).to be_falsy
         end
+
+        it 'does not blow up on buggy classes that raise weird errors on `to_str`' do
+          allow(Foo::Bar).to receive(:to_str).and_raise("boom!")
+          const, _ = recursive_const_defined?('::RSpec::Support::Foo::Bar::VAL')
+
+          expect(const).to eq(10)
+        end
       end
 
       describe '#recursive_const_get' do


### PR DESCRIPTION
Instead of letting `Array#join` try to use `to_str` on the module.

This works around buggy modules/classes that raise odd errors from
`to_str`. This fixes rspec/rspec-mocks#1161.