### PR TITLE
Fix diffs for hashes inside arrays, by ordering keys

### DIFF
--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -73,11 +73,19 @@ module RSpec
 
       def prepare_hash(input_hash)
         with_entering_structure(input_hash) do
-          input_hash.inject({}) do |output_hash, key_and_value|
+          sort_hash_keys(input_hash).inject({}) do |output_hash, key_and_value|
             key, value = key_and_value.map { |element| prepare_element(element) }
             output_hash[key] = value
             output_hash
           end
+        end
+      end
+
+      def sort_hash_keys(input_hash)
+        if input_hash.keys.all? { |k| k.is_a?(String) || k.is_a?(Symbol) }
+          Hash[input_hash.sort_by { |k, _v| k.to_s }]
+        else
+          input_hash
         end
       end
 

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -228,6 +228,27 @@ EOD
           expect(diff).to be_diffed_as(expected_diff)
         end
 
+        unless RUBY_VERSION == '1.8.7' # We can't count on the ordering of the hash on 1.8.7...
+          it "outputs unified diff message for hashes inside arrays with differing key orders" do
+            expected = [{ :foo => 'bar', :baz => 'quux', :metasyntactic => 'variable', :delta => 'charlie', :width =>'quite wide' }]
+            actual   = [{ :metasyntactic => 'variable', :delta => 'charlotte', :width =>'quite wide', :foo => 'bar' }]
+
+            expected_diff = <<'EOD'
+
+@@ -1,4 +1,5 @@
+-[{:delta=>"charlotte",
++[{:baz=>"quux",
++  :delta=>"charlie",
+   :foo=>"bar",
+   :metasyntactic=>"variable",
+   :width=>"quite wide"}]
+EOD
+
+            diff = differ.diff(expected,actual)
+            expect(diff).to be_diffed_as(expected_diff)
+          end
+        end
+
         it 'outputs unified diff message of two hashes with differing encoding', :failing_on_appveyor do
           expected_diff = %Q{
 @@ -1,2 +1,2 @@

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -32,6 +32,18 @@ module RSpec
         end
       end
 
+      unless RUBY_VERSION == '1.8.7' # We can't count on the ordering of the hash on 1.8.7...
+        context 'with a hash object' do
+          let(:input) { { :c => "ccc", :a => "aaa", "b" => 'bbb' } }
+          let(:expected) { '{:a=>"aaa", "b"=>"bbb", :c=>"ccc"}' }
+
+          it 'sorts keys to ensure objects are always displayed the same way' do
+            formatted = ObjectFormatter.format(input)
+            expect(formatted).to eq expected
+          end
+        end
+      end
+
       context 'with Time objects' do
         let(:time) { Time.utc(1969, 12, 31, 19, 01, 40, 101) }
         let(:formatted_time) { ObjectFormatter.format(time) }


### PR DESCRIPTION
Hi! 

I noticed diffs were sometimes incorrect when mocking calls and checking hash arguments. See example specs & output here:
https://github.com/jcrisp/rspec-mocks/commit/28e88c4a6cd8f3887c42b0beefa4a3312a120230 

On digging further, it looked best to fix this in rspec-support by ordering the keys in hashes when they are nested in arrays. Happy to improve the PR or redo elsewhere in rspec if you'd prefer.

Cheers
James
