### PR TITLE
Upgrade rubocop, motivated by CVE.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,25 @@
-inherit_from: .rubocop_rspec_base.yml
+inherit_from:
+  - .rubocop_rspec_base.yml
+
+Metrics/AbcSize:
+  Max: 28
+
+Metrics/BlockLength:
+  Max: 86
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Security/MarshalLoad:
+  Exclude:
+    - 'lib/rspec/support/spec/in_sub_process.rb'
+
+Style/EvalWithLocation:
+  Exclude:
+    # eval is only used here to check syntax
+    - 'lib/rspec/support/ruby_features.rb'
+
+Lint/AssignmentInCondition:
+  Exclude:
+    # The pattern makes sense here
+    - 'lib/rspec/support/mutex.rb'

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,11 +1,8 @@
-# This file was generated on 2017-12-30T17:04:25-08:00 from the rspec-dev repo.
-# DO NOT modify it by hand as your changes will get lost the next time it is generated.
-
 # This file contains defaults for RSpec projects. Individual projects
 # can customize by inheriting this file and overriding particular settings.
 
 AccessModifierIndentation:
-  EnforcedStyle: outdent
+  Enabled: false
 
 # "Use alias_method instead of alias"
 # We're fine with `alias`.
@@ -50,9 +47,6 @@ DoubleNegation:
 EachWithObject:
   Enabled: false
 
-Encoding:
-  EnforcedStyle: when_needed
-
 FormatString:
   EnforcedStyle: percent
 
@@ -73,7 +67,7 @@ MethodLength:
   Max: 15
 
 # Who cares what we call the argument for binary operator methods?
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 PercentLiteralDelimiters:
@@ -98,9 +92,6 @@ PredicateName:
 Proc:
   Enabled: false
 
-RedundantReturn:
-  AllowMultipleReturnValues: true
-
 # Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
 RescueException:
   Enabled: true
@@ -121,10 +112,196 @@ StringLiterals:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
   Enabled: false
 
 TrivialAccessors:
   AllowDSLWriters: true
   AllowPredicates: true
   ExactNameMatch: true
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/YodaCondition:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+# This could likely be enabled, but it had a false positive on rspec-mocks
+# (suggested change was not behaviour preserving) so I don't trust it.
+Performance/HashEachMethods:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentAssignment:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/StructInheritance:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/DateTime:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Lint/ImplicitStringConcatenation:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|min
   gem 'ffi', '< 1.9.15' # allow ffi to be installed on older rubies on windows
 end
 
-if RUBY_VERSION >= '2.0' && RUBY_VERSION <= '2.1'
-  gem 'rubocop', "~> 0.23.0"
+if RUBY_VERSION >= '2.0'
+  gem 'rubocop', "~> 0.52.1"
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,9 @@ if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|min
   gem 'ffi', '< 1.9.15' # allow ffi to be installed on older rubies on windows
 end
 
-if RUBY_VERSION >= '2.0'
-  gem 'rubocop', "~> 0.52.1"
+# No need to run rubocop on earlier versions
+if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
+  gem "rubocop", "~> 0.52.1"
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -5,7 +5,7 @@ module RSpec
     # Provide additional output details beyond what `inspect` provides when
     # printing Time, DateTime, or BigDecimal
     # @api private
-    class ObjectFormatter # rubocop:disable Style/ClassLength
+    class ObjectFormatter # rubocop:disable Metrics/ClassLength
       ELLIPSIS = "..."
 
       attr_accessor :max_formatted_output_length
@@ -31,15 +31,15 @@ module RSpec
 
       def format(object)
         if max_formatted_output_length.nil?
-          return prepare_for_inspection(object).inspect
+          prepare_for_inspection(object).inspect
         else
           formatted_object = prepare_for_inspection(object).inspect
           if formatted_object.length < max_formatted_output_length
-            return formatted_object
+            formatted_object
           else
             beginning = truncate_string formatted_object, 0, max_formatted_output_length / 2
             ending = truncate_string formatted_object, -max_formatted_output_length / 2, -1
-            return beginning + ELLIPSIS + ending
+            beginning + ELLIPSIS + ending
           end
         end
       end

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -109,7 +109,6 @@ module RSpec
         end
       else
         # RBX / JRuby et al support is unknown for keyword arguments
-        # rubocop:disable Lint/Eval
         begin
           eval("o = Object.new; def o.m(a: 1); end;"\
                " raise SyntaxError unless o.method(:m).parameters.include?([:key, :a])")
@@ -147,7 +146,6 @@ module RSpec
             false
           end
         end
-        # rubocop:enable Lint/Eval
       end
 
       def module_refinement_supported?

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -180,7 +180,7 @@ function check_documentation_coverage {
 
 function check_style_and_lint {
   echo "bin/rubocop lib"
-  bin/rubocop lib
+  eval "(unset RUBYOPT; exec bin/rubocop lib)"
 }
 
 function run_all_spec_suites {


### PR DESCRIPTION
Defaulted most new things to off, though tried to keep performance and linters.

Note that `.rubocop_rspec_base` doesn't 100% match up with `rspec-dev` because I was adding to it as we went along. Once these are all merged I'm planning to ensure they're all consistent.