### PR TITLE
Workaround JRuby incompatibilities

### DIFF
--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -719,6 +719,16 @@ module RSpec
             expect(valid_non_kw_args?(2)).to eq false
           end
         end
+
+        if Ruby.jruby?
+          describe 'a single-argument Java method' do
+            let(:test_method) { Java::JavaLang::String.instance_method(:char_at) }
+
+            it 'validates against a single argument' do
+              expect(valid_non_kw_args?(1)).to eq true
+            end
+          end
+        end
       end
 
       let(:fake_matcher) { Object.new }

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -727,6 +727,14 @@ module RSpec
             it 'validates against a single argument' do
               expect(valid_non_kw_args?(1)).to eq true
             end
+
+            it 'fails validation against 0 arguments' do
+              expect(valid_non_kw_args?(0)).to eq false
+            end
+
+            it 'fails validation against 2 arguments' do
+              expect(valid_non_kw_args?(2)).to eq false
+            end
           end
         end
       end


### PR DESCRIPTION
JRuby apparently only supports #arity (and not #parameters) for Java proxy methods (see https://github.com/jruby/jruby/issues/2817), but verifying doubles in RSpec use #parameters to infer required method parameters, and thus doesn't work for Java classes.

This extends the previously existing JRuby workaround that returns an empty list from #parameters so that it fallbacks to the legacy method of using #arity.

In addition, it turns out that the #arity method is broken for Java proxy methods in JRuby 1.7.x. While JRuby 1.7 has been sunset, the test suite still uses it, and thus this introduces another workaround to account for that.

This looks up the corresponding JavaMethod overloads, and if there is only one, retrieves the arity from that one instead. In the presence of multiple overloads, -1 is returned.

While this obviously doesn't cover all cases, it does cover the cases the previous workaround covered, and also allows using verifying doubles for many Java classes in JRuby.