### PR TITLE
Adapt JRuby arity workaround to BlockSignature

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -180,13 +180,19 @@ module RSpec
       # aliases to make method names look more Rubyesque). If there is only a
       # single match, we can use that methods arity directly instead of the
       # default -1 arity.
+      #
+      # This workaround only works for Java proxy methods, and in order to
+      # support regular methods and blocks, we need to be careful about calling
+      # owner and java_class as they might not be available
       if Java::JavaLang::String.instance_method(:char_at).arity == -1
         class MethodSignature < remove_const(:MethodSignature)
         private
 
           def classify_parameters
             super
-            return unless @method.arity == -1 && @method.owner.respond_to?(:java_class)
+            return unless @method.arity == -1
+            return unless @method.respond_to?(:owner)
+            return unless @method.owner.respond_to?(:java_class)
             java_instance_methods = @method.owner.java_class.java_instance_methods
             compatible_overloads = java_instance_methods.select do |java_method|
               @method == @method.owner.instance_method(java_method.name)


### PR DESCRIPTION
The workaround looking up the corresponding Java class and looking at its methods only works for methods, and doesn't work for Proc, where there isn't a direct API to access the proxied Java class.

While the same problem exists for Proc's, until https://github.com/jruby/jruby/issues/2817 has been resolved, there isn't much that can be done for that case. However, the current code fails to run for all blocks with arity -1, so this tweak is necessary to ensure normal blocks work again.

I couldn't find any specs for BlockSignature, so wasn't sure where it would be appropriate to add a test for this.