### PR TITLE
Prevent NoMethodError when setting a message expectation on an instance of a package-protected class

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -187,13 +187,19 @@ module RSpec
       if Java::JavaLang::String.instance_method(:char_at).arity == -1
         class MethodSignature < remove_const(:MethodSignature)
         private
+          def java_instance_methods
+            if @method.owner.java_class.public?
+              [@method.owner.java_class]
+            else
+              @method.owner.java_class.interfaces + [@method.owner.java_class.generic_superclass]
+            end.select(&:public?).map(&:java_instance_methods).flatten
+          end
 
           def classify_parameters
             super
             return unless @method.arity == -1
             return unless @method.respond_to?(:owner)
             return unless @method.owner.respond_to?(:java_class)
-            java_instance_methods = @method.owner.java_class.java_instance_methods
             compatible_overloads = java_instance_methods.select do |java_method|
               @method == @method.owner.instance_method(java_method.name)
             end


### PR DESCRIPTION
An Java object can be an instance of a class that is
package-protected but implements or inherits from
a public type.  In that situation, the object's proxy
will only implement methods of its public interfaces
and superclasses, but `java_instance_methods` will
include methods that are defined on the
package-protected class.

For example:

    // Java code
    public interface A {
      public void runA();
    }

    class B implements A {
      public void runA() {}
      public void runB() {}
    }

    # Ruby code
    b = B.new
    b.java_class.java_instance_methods.map(&:name) #=> contains `:run_a` and `:run_b`
    b.method(:run_a) # => Returns a Method
    b.method(:run_b) # => raises a NoMethodError