### PR TITLE
Prevent invalid encoding for files blowing up `Source.from_file`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,12 @@ jobs:
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
       NO_COVERAGE: true
     steps:
-      - uses: actions/checkout@v3
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - run: git init $GITHUB_WORKSPACE
+      - run: git remote add origin https://github.com/rspec/rspec-support
+      - run: git config --local gc.auto 0
+      - run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +$GITHUB_SHA:$GITHUB_REF
+      - run: git checkout --progress --force $GITHUB_REF
       - run: ${{ matrix.container.pre }}
       - run: script/legacy_setup.sh
       - run: ${{ matrix.container.post }}

--- a/lib/rspec/support/source.rb
+++ b/lib/rspec/support/source.rb
@@ -14,14 +14,22 @@ module RSpec
       # stubbed out within tests.
       class File
         class << self
-          [:read, :expand_path].each do |method_name|
-            define_method(method_name, &::File.method(method_name))
+          define_method(:expand_path, &::File.method(:expand_path))
+
+          if RUBY_VERSION.to_f > 1.9
+            define_method(:binread, &::File.method(:binread))
+          else
+            define_method(:binread, &::File.method(:read))
           end
         end
       end
 
       def self.from_file(path)
-        source = File.read(path)
+        # We must use `binread` here, there is no spec for this behaviour
+        # as its proven troublesome to replicate within our spec suite, but
+        # to manually verify run:
+        # `bundle exec rspec spec/support/source_broken_example`
+        source = File.binread(path)
         new(source, path)
       end
 

--- a/spec/support/source_broken_example
+++ b/spec/support/source_broken_example
@@ -1,0 +1,8 @@
+Encoding.default_internal = Encoding::BINARY
+
+describe UndeclaredModule do
+  # the missing constant can be anything
+  it 'crashes and does not even parse this' do
+    'привет'
+  end
+end


### PR DESCRIPTION
From rspec/rspec#102 an invalid encoding combination in a file can cause an error which stops RSpec from running and highlighting the correct cause:
```
Traceback (most recent call last):
	28: from bin/ruby_executable_hooks:24:in `<main>'
	27: from bin/ruby_executable_hooks:24:in `eval'
	26: from bin/rspec:23:in `<main>'
	25: from bin/rspec:23:in `load'
	24: from gems/rspec-core-3.8.0/exe/rspec:4:in `<top (required)>'
	23: from gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in `invoke'
	22: from gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in `run'
	21: from gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:86:in `run'
	20: from gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:98:in `setup'
	19: from gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1558:in `load_spec_files'
	18: from gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1558:in `each'
	17: from gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1560:in `block in load_spec_files'
	16: from gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:2033:in `load_file_handling_errors'
	15: from gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:2037:in `rescue in load_file_handling_errors'
	14: from gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:161:in `notify_non_example_exception'
	13: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:78:in `fully_formatted'
	12: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:86:in `fully_formatted_lines'
	11: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:240:in `formatted_message_and_backtrace'
	10: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:34:in `colorized_message_lines'
	 9: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:149:in `failure_lines'
	 8: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:149:in `tap'
	 7: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:150:in `block in failure_lines'
	 6: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:163:in `failure_slash_error_lines'
	 5: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/exception_presenter.rb:218:in `read_failed_lines'
	 4: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/snippet_extractor.rb:30:in `extract_expression_lines_at'
	 3: from gems/rspec-core-3.8.0/lib/rspec/core/formatters/snippet_extractor.rb:18:in `source_from_file'
	 2: from gems/rspec-core-3.8.0/lib/rspec/core/world.rb:150:in `source_from_file'
	 1: from gems/rspec-support-3.8.0/lib/rspec/support/source.rb:12:in `from_file'
gems/rspec-support-3.8.0/lib/rspec/support/source.rb:12:in `read': U+043F from UTF-8 to ASCII-8BIT (Encoding::UndefinedConversionError)
```

After this PR:

```
An error occurred while loading ./spec/support/source_spec.broken_example.
Failure/Error: Unable to find matching line in ./spec/support/source_spec.broken_example

NameError:
  uninitialized constant UndeclaredModule
```