### PR TITLE
Recognize hash as optional arg when optional keyword is present

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -77,17 +77,18 @@ module RSpec
           given_kw_args - @allowed_kw_args
         end
 
+        # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
+        # the rest will be grouped in another Hash and passed as positional argument.
         def has_kw_args_in?(args)
-          Hash === args.last && could_contain_kw_args?(args)
+          Hash === args.last &&
+            could_contain_kw_args?(args) &&
+            args.last.keys.any? { |x| x.is_a?(Symbol) }
         end
 
         # Without considering what the last arg is, could it
         # contain keyword arguments?
         def could_contain_kw_args?(args)
           return false if args.count <= min_non_kw_args
-          return false if args.count <= max_non_kw_args &&
-            Hash === args.last &&
-            args.last.keys.none? { |x| x.is_a?(Symbol) }
 
           @allows_any_kw_args || @allowed_kw_args.any?
         end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -361,7 +361,14 @@ module RSpec
 
       def split_args(*args)
         kw_args = if @signature.has_kw_args_in?(args)
-                    args.pop.keys
+                    last = args.pop
+                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) }
+                    if non_kw_args.empty?
+                      last.keys
+                    else
+                      args << non_kw_args
+                      last.select { |k, _| k.is_a?(Symbol) }.keys
+                    end
                   else
                     []
                   end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -85,6 +85,10 @@ module RSpec
         # contain keyword arguments?
         def could_contain_kw_args?(args)
           return false if args.count <= min_non_kw_args
+          return false if args.count <= max_non_kw_args &&
+            Hash === args.last &&
+            args.last.keys.none? { |x| x.is_a?(Symbol) }
+
           @allows_any_kw_args || @allowed_kw_args.any?
         end
 

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -384,13 +384,17 @@ module RSpec
               expect(valid?(nil, :a => 1)).to eq(false)
             end
 
-            it 'allows Hash containing strings as last argument' do
+            it 'treats symbols as keyword arguments and the rest as optional argument' do
               expect(valid?(nil, 'a' => 1)).to eq(true)
+              expect(valid?(nil, 'a' => 1, :z => 3)).to eq(true)
+              expect(valid?(nil, 'a' => 1, :b => 3)).to eq(false)
+              expect(valid?(nil, 'a' => 1, :b => 2, :z => 3)).to eq(false)
             end
 
             it 'mentions the invalid keyword args in the error', :pending => RSpec::Support::Ruby.jruby? && !RSpec::Support::Ruby.jruby_9000? do
-              expect(error_for(nil, nil, :a => 0)).to \
-                eq("Invalid keyword arguments provided: a")
+              expect(error_for(1, 2, :a => 0)).to eq("Invalid keyword arguments provided: a")
+              expect(error_for(1, :a => 0)).to eq("Invalid keyword arguments provided: a")
+              expect(error_for(1, 'a' => 0, :b => 0)).to eq("Invalid keyword arguments provided: b")
             end
 
             it 'describes invalid arity precisely' do


### PR DESCRIPTION
I hit an issue in one of the projects that I work that I've reported in [rspec-mocks#1266](https://github.com/rspec/rspec-mocks/issues/1266).

In short, given `foo(a, b = {}, x: false)` should recognize a valid method call with args: `foo(1, a: 1, b: 2)`.

I've opted to extend the spec for optional keywords. I'm feeling lost in the specs, so please, give me some pointers if you need the specs re-worked.

I'm OK if you want to change the implementation or try to catch edge cases involving splats.