### PR TITLE
Check for nil instead of truthiness when making a diff

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -11,7 +11,7 @@ module RSpec
       def diff(actual, expected)
         diff = ""
 
-        if actual && expected
+        unless actual.nil? || expected.nil?
           if all_strings?(actual, expected)
             if any_multiline_strings?(actual, expected)
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -468,6 +468,13 @@ EOD
             expect(diff).to be_diffed_as(expected_diff)
           end
         end
+
+        context 'when expected or actual is false' do
+          it 'generates a diff' do
+            expect(differ.diff(true, false)).to_not be_empty
+            expect(differ.diff(false, true)).to_not be_empty
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Previous Behavior

The following lines create different output:

```ruby
expect(true).to match a_falsy_value

# =>
       expected true to match (a falsey value)
       Diff:
       @@ -1,2 +1,2 @@
       -(a falsey value)
       +true
```

```ruby
expect(false).to match a_truthy_value

# =>
       expected false to match (a truthy value)
```

The first generates a diff, whereas the second does not. This is because the actual and expected values are checked for presence with `if actual && expected` when creating the diff. In the first example, the actual is true, so it passes the check. In the second, the actual is false and the diff returned is an empty string.

## New Behavior

These should be consistent with each other. The two options would be to make them both create a diff or modify the matcher so neither do. However, since all other `match(something)` matchers produce a diff output, it makes sense to do the same here.

If it is necessary for that check to also check for truthiness, then another solution could be found. But, I cannot find a situation where false would be passed in where we wouldn't want to create a diff.