### PR TITLE
\r should be escaped when inside an array

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+
+* Escape \r when outputting strings inside arrays.
+  (Tomita Masahiro, Jon Rowe, #378)
+
 ### 3.8.2 / 2019-06-10
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.8.1...v3.8.2)
 

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -97,7 +97,7 @@ module RSpec
           if Array === entry
             entry.inspect
           else
-            entry.to_s.gsub("\n", "\\n")
+            entry.to_s.gsub("\n", "\\n").gsub("\r", "\\r")
           end
         end
       end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -209,6 +209,17 @@ EOD
           expect(diff).to be_diffed_as(expected_diff)
         end
 
+        it 'outputs unified diff message of strings in arrays' do
+          diff = differ.diff(["a\r\nb"], ["a\r\nc"])
+          expected_diff = <<-EOD
+
+@@ -1,2 +1,2 @@
+-a\\r\\nc
++a\\r\\nb
+EOD
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+
         it "outputs unified diff message of two hashes" do
           expected = { :foo => 'bar', :baz => 'quux', :metasyntactic => 'variable', :delta => 'charlie', :width =>'quite wide' }
           actual   = { :foo => 'bar', :metasyntactic => 'variable', :delta => 'charlotte', :width =>'quite wide' }


### PR DESCRIPTION
To prevent terminal rewinding, we should escape `\r`, replaces #293