### PR TITLE
Prevent Rakefile from loading rubocop when dependency is not present

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,8 +23,12 @@ end
 
 task :build => :verify_private_key_present
 
-require 'rubocop/rake_task'
-desc 'Run RuboCop on the lib directory'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['lib/**/*.rb']
+begin
+  require 'rubocop/rake_task'
+  desc 'Run RuboCop on the lib directory'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.patterns = ['lib/**/*.rb']
+  end
+rescue LoadError
+  # No rubocop means no rubocop rake task
 end


### PR DESCRIPTION
I encountered the following error:
```
% bundle exec rake spec
rake aborted!
cannot load such file -- rubocop/rake_task
```
because the `Gemfile` has the following condition for including this dependency:
```
if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
  gem "rubocop", "~> 0.52.1"
end
```
So, I've added the same condition to the `Rakefile`.