### PR TITLE
Don't raise exception on JRuby 9k < 9.2.1.0

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -111,7 +111,8 @@ module RSpec
         ripper_requirements.push(Ruby.jruby_version >= '1.7.5')
         # Ripper on JRuby 9.0.0.0.rc1 - 9.1.8.0 reports wrong line number
         # or cannot parse source including `:if`.
-        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.1.8.0'))
+        # Ripper on JRuby 9.x.x.x < 9.2.1.0 can't handle keyword arguments.
+        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.2.0.0'))
       end
 
       if ripper_requirements.all?

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -120,7 +120,8 @@ module RSpec
 
         def ripper_works_correctly?
           ripper_reports_correct_line_number? &&
-            ripper_can_parse_source_including_keywordish_symbol?
+            ripper_can_parse_source_including_keywordish_symbol? &&
+            ripper_can_parse_source_referencing_keyword_arguments?
         end
 
         # https://github.com/jruby/jruby/issues/3386
@@ -141,6 +142,25 @@ module RSpec
             require 'ripper'
             sexp = ::Ripper.sexp(':if')
             !sexp.nil?
+          end
+        end
+
+        # https://github.com/jruby/jruby/issues/5209
+        def ripper_can_parse_source_referencing_keyword_arguments?
+          in_sub_process_if_possible do
+            require 'ripper'
+            # It doesn't matter if keyword arguments don't exist.
+            if Ruby.mri? || Ruby.jruby?
+              if RUBY_VERSION < '2.0'
+                true
+              else
+                begin
+                  !::Ripper.sexp('def a(**kw_args); end').nil?
+                rescue NoMethodError
+                  false
+                end
+              end
+            end
           end
         end
 


### PR DESCRIPTION
JRuby 9k 9.2.0.0 and lower will has a bug in Ripper.sexp that raises a
NoMethodError when analyzing code that even references a method with
keyword arguments. This makes failure formatting raise that exception.
Best to just not use Ripper on JRuby 9k < 9.2.1.0.

[Fixes #399]