### PR TITLE
Add helper for running class_exec with keywords when needed

### DIFF
--- a/lib/rspec/support/with_keywords_when_needed.rb
+++ b/lib/rspec/support/with_keywords_when_needed.rb
@@ -1,0 +1,33 @@
+RSpec::Support.require_rspec_support("method_signature_verifier")
+
+module RSpec
+  module Support
+    module WithKeywordsWhenNeeded
+      # This module adds keyword sensitive support for core ruby methods
+      # where we cannot use `ruby2_keywords` directly.
+
+      module_function
+
+      if RSpec::Support::RubyFeatures.kw_args_supported?
+        # Remove this in RSpec 4 in favour of explictly passed in kwargs where
+        # this is used. Works around a warning in Ruby 2.7
+
+        def class_exec(klass, *args, &block)
+          if MethodSignature.new(block).has_kw_args_in?(args)
+            binding.eval(<<-CODE, __FILE__, __LINE__)
+            kwargs = args.pop
+            klass.class_exec(*args, **kwargs, &block)
+            CODE
+          else
+            klass.class_exec(*args, &block)
+          end
+        end
+        ruby2_keywords :class_exec if respond_to?(:ruby2_keywords, true)
+      else
+        def class_exec(klass, *args, &block)
+          klass.class_exec(*args, &block)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/support/with_keywords_when_needed_spec.rb
+++ b/spec/rspec/support/with_keywords_when_needed_spec.rb
@@ -1,0 +1,48 @@
+require 'rspec/support/with_keywords_when_needed'
+
+module RSpec::Support
+  RSpec.describe "WithKeywordsWhenNeeded" do
+
+    describe ".class_exec" do
+      extend RubyFeatures
+
+      let(:klass) do
+        Class.new do
+          def self.check_argument(argument)
+            raise ArgumentError unless argument == 42
+          end
+        end
+      end
+
+      def run(klass, *args, &block)
+        WithKeywordsWhenNeeded.class_exec(klass, *args, &block)
+      end
+
+      it "will run a block without keyword arguments" do
+        run(klass, 42) { |arg| check_argument(arg) }
+      end
+
+      it "will run a block with a hash with out keyword arguments" do
+        run(klass, "value" => 42) { |arg| check_argument(arg["value"]) }
+      end
+
+      it "will run a block with optional keyword arguments when none are provided", :if => kw_args_supported? do
+        binding.eval(<<-CODE, __FILE__, __LINE__)
+        run(klass, 42) { |arg, val: nil| check_argument(arg) }
+        CODE
+      end
+
+      it "will run a block with optional keyword arguments when they are provided", :if => required_kw_args_supported? do
+        binding.eval(<<-CODE, __FILE__, __LINE__)
+        run(klass, val: 42) { |val: nil| check_argument(val) }
+        CODE
+      end
+
+      it "will run a block with required keyword arguments", :if => required_kw_args_supported? do
+        binding.eval(<<-CODE, __FILE__, __LINE__)
+        run(klass, val: 42) { |val:| check_argument(val) }
+        CODE
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an extraction from a pr on rspec-core but its going to be a repeated pattern to fix keyword arguments across the gem so I'm adding it here. I expect to add more as I find other places that keyword arguments don't work quite right.

The aim will be to keep the string eval to a minimum and this will all be replaced with proper `**kwargs` in RSpec 4, which I want to release in the later half of this year before the next version of Ruby.