### PR TITLE
Ignore JRuby warning

### DIFF
--- a/lib/rspec/support/spec/shell_out.rb
+++ b/lib/rspec/support/spec/shell_out.rb
@@ -66,6 +66,8 @@ module RSpec
           l =~ %r{lib/ruby/stdlib/jar} ||
           # This is a JRuby file that generates warnings on 9.1.7.0
           l =~ %r{org/jruby/RubyKernel\.java} ||
+          # This is a JRuby gem that generates warnings on 9.1.7.0
+          l =~ %r{ffi-1\.13\.\d-java} ||
           # Remove blank lines
           l == "" || l.nil?
         end.join("\n")


### PR DESCRIPTION
Fixes the travis builds for `rspec-expectations`