### PR TITLE
Add special case for Class.new method signature that should use initialize signature instead

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -164,7 +164,7 @@ module RSpec
       def method_or_class_initialize(method)
         # Support only not redefined Class.new
         return method if !method.respond_to?(:owner) || method.owner != Class
-        return method if !method.respond_to?(:name) || method.name != :new
+        return method if !method.respond_to?(:name) || method.name.to_s != 'new'
         method.receiver.instance_method(:initialize)
       end
     end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -12,7 +12,7 @@ module RSpec
       attr_reader :min_non_kw_args, :max_non_kw_args, :optional_kw_args, :required_kw_args
 
       def initialize(method)
-        @method           = method
+        @method           = method_or_class_initialize(method)
         @optional_kw_args = []
         @required_kw_args = []
         classify_parameters
@@ -158,6 +158,15 @@ module RSpec
       end
 
       INFINITY = 1 / 0.0
+
+      private
+
+      def method_or_class_initialize(method)
+        # Support only not redefined Class.new
+        return method if !method.respond_to?(:owner) || method.owner != Class
+        return method if !method.respond_to?(:name) || method.name != :new
+        method.receiver.instance_method(:initialize)
+      end
     end
 
     if RSpec::Support::Ruby.jruby?

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -162,9 +162,9 @@ module RSpec
       private
 
       def method_or_class_initialize(method)
-        # Support only not redefined Class.new
-        return method if !method.respond_to?(:owner) || method.owner != Class
-        return method if !method.respond_to?(:name) || method.name.to_s != 'new'
+        return method if method.is_a? Proc # included shared examples
+        # Special treatment for stubbing `Class.new`
+        return method unless method.owner == Class && method.name == :new
         method.receiver.instance_method(:initialize)
       end
     end

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -817,6 +817,63 @@ module RSpec
           end
         end
 
+        describe 'an `.new` method' do
+          old_verbose, $VERBOSE = $VERBOSE, false
+          class TestInitializeClass; def initialize(arg1, arg2); end; end
+          class TestNewClass; def self.new(arg1, arg2, arg3); super; end; end
+          $VERBOSE = old_verbose
+
+          describe 'for pure Class' do
+            let(:test_method) { Class.method(:new) }
+
+            it 'match unlimited arguments' do
+              expect(validate_expectation :unlimited_args).to eq(true)
+            end
+
+            it 'validates against 2 arguments' do
+              expect(valid_non_kw_args?(2)).to eq true
+            end
+
+            it 'validates against 2 arguments' do
+              expect(valid_non_kw_args?(3)).to eq true
+            end
+          end
+
+          describe 'for class with initialize method' do
+
+
+            let(:test_method) { TestInitializeClass.method(:new) }
+
+            it 'does not match unlimited arguments' do
+              expect(validate_expectation :unlimited_args).to eq(false)
+            end
+
+            it 'validates against 2 arguments' do
+              expect(valid_non_kw_args?(2)).to eq true
+            end
+
+            it 'fails validation against 3 arguments' do
+              expect(valid_non_kw_args?(3)).to eq false
+            end
+          end
+
+          describe 'for class with owerwritten new method' do
+            let(:test_method) { TestNewClass.method(:new) }
+
+            it 'does not match unlimited arguments' do
+              expect(validate_expectation :unlimited_args).to eq(false)
+            end
+
+            it 'fails validation against 2 arguments' do
+              expect(valid_non_kw_args?(2)).to eq false
+            end
+
+            it 'validates against 3 arguments' do
+              expect(valid_non_kw_args?(3)).to eq true
+            end
+          end
+        end
+
         if Ruby.jruby?
           describe 'a single-argument Java method' do
             let(:test_method) { Java::JavaLang::String.instance_method(:char_at) }


### PR DESCRIPTION
While investigating https://github.com/rspec/rspec-mocks/pull/1324 it turned out that while for most cases RSpec::Support::MethodSignature returns correct signature, for `.new` there is still some room for improvement.

In Ruby native `Class::new` is a direct proxy to `Class#initialize` method. As a result in cases like [this](https://github.com/rspec/rspec-mocks/pull/1324#issuecomment-609468331) signature reported by `.new` is different from `#initialize`, but Ruby will blame caller of `new`, not `new` itself. You can see it using following script:

```
class A
  def initialize(args:)
  end
end

class B
  def self.new(*args)
    super
  end

  def initialize(args:)
  end
end

hash = { args: true }
A.new(hash)
puts A.method(:new).inspect

B.new(hash)
puts B.method(:new).inspect
```

With changes to Keyword arguments in 2.7 this is leading to weird situations when random libraries are blamed for disparity between `new` and `initialize` signature. This PR fixes it by reaching to `initialize` if native `Class.new` is called - in any other case (i.e. when `new` is redefined) it will fall back to native behaviour.