### PR TITLE
`diff-lcs` has changed its format in 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
   include:
     - rvm: jruby-1.7
       env: JRUBY_OPTS='--dev --1.8'
+    - rvm: 2.7.1
+      env: DIFF_LCS_VERSION="~> 1.3.0"
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,12 @@ else
   gem 'rake', '>= 12.3.3'
 end
 
+if ENV['DIFF_LCS_VERSION']
+  gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
+else
+  gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
+end
+
 if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem "childprocess", "< 1.0.0"
 elsif RUBY_VERSION < '2.3.0'

--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -2,6 +2,7 @@ require 'rspec/support'
 require 'rspec/support/spec/in_sub_process'
 
 RSpec::Support.require_rspec_support "spec/deprecation_helpers"
+RSpec::Support.require_rspec_support "spec/diff_helpers"
 RSpec::Support.require_rspec_support "spec/with_isolated_stderr"
 RSpec::Support.require_rspec_support "spec/stderr_splitter"
 RSpec::Support.require_rspec_support "spec/formatting_support"

--- a/lib/rspec/support/spec/diff_helpers.rb
+++ b/lib/rspec/support/spec/diff_helpers.rb
@@ -1,0 +1,29 @@
+require 'diff/lcs'
+
+module RSpec
+  module Support
+    module Spec
+      module DiffHelpers
+        # In the updated version of diff-lcs several diff headers change format slightly
+        # compensate for this and change minimum version in RSpec 4
+        if ::Diff::LCS::VERSION.to_f < 1.4
+          def one_line_header(line_number=2)
+            "-1,#{line_number} +1,#{line_number}"
+          end
+
+          def removing_two_line_header
+            "-1,3 +1"
+          end
+        else
+          def one_line_header(_=2)
+            "-1 +1"
+          end
+
+          def removing_two_line_header
+            "-1,3 +1,5"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -7,16 +7,7 @@ require 'rspec/support/spec/string_matcher'
 module RSpec
   module Support
     RSpec.describe Differ do
-
-      # In the updated version of diff-lcs several diff headers change format slightly
-      # compensate for this and change minimum version in RSpec 4
-      if Diff::LCS::VERSION.to_f < 1.4
-        one_line_header = "-1,2 +1,2"
-        removing_two_line_header = "-1,3 +1"
-      else
-        one_line_header = "-1 +1"
-        removing_two_line_header = "-1,3 +1,5"
-      end
+      include Spec::DiffHelpers
 
       describe '#diff' do
         let(:differ) { RSpec::Support::Differ.new }


### PR DESCRIPTION
The recent `diff-lcs` update changed some parts of the diff output, breaking our builds, these seem trivial enough to ignore (e.g. they don't seem wrong, just different).

Draft because I'm going to improve the formatting of this spec a bit whilst I'm here, and I'm going to setup CI to test both versions of `diff-lcs`.