### PR TITLE
Exclude internal methods in the caller filter

### DIFF
--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -25,7 +25,7 @@ module RSpec
     # when `CallerFilter.first_non_rspec_line` is called from the top level of a required
     # file, but it depends on if rubygems is loaded or not. We don't want to have to deal
     # with this complexity in our `RSpec.deprecate` calls, so we ignore it here.
-    IGNORE_REGEX = Regexp.union(LIB_REGEX, "rubygems/core_ext/kernel_require.rb")
+    IGNORE_REGEX = Regexp.union(LIB_REGEX, "rubygems/core_ext/kernel_require.rb", /^<internal:/)
 
     if RSpec::Support::RubyFeatures.caller_locations_supported?
       # This supports args because it's more efficient when the caller specifies


### PR DESCRIPTION
This filters internal ruby implementation methods by filtering lines that include `<internal`.