### PR TITLE
Update ripper_supported? for TruffleRuby to true

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -105,7 +105,7 @@ module RSpec
       end
       ripper_requirements = [ComparableVersion.new(RUBY_VERSION) >= '1.9.2']
 
-      ripper_requirements.push(false) if Ruby.rbx? || Ruby.truffleruby?
+      ripper_requirements.push(false) if Ruby.rbx?
 
       if Ruby.jruby?
         ripper_requirements.push(Ruby.jruby_version >= '1.7.5')

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -150,7 +150,7 @@ module RSpec
           in_sub_process_if_possible do
             require 'ripper'
             # It doesn't matter if keyword arguments don't exist.
-            if Ruby.mri? || Ruby.jruby?
+            if Ruby.mri? || Ruby.jruby? || Ruby.truffleruby?
               if RUBY_VERSION < '2.0'
                 true
               else


### PR DESCRIPTION
TruffleRuby now supports `ripper` in the current release version.