### PR TITLE
Allow File.read to be stubbed out without breaking ripper support

### DIFF
--- a/lib/rspec/support/source.rb
+++ b/lib/rspec/support/source.rb
@@ -8,6 +8,16 @@ module RSpec
     class Source
       attr_reader :source, :path
 
+      # This class protects us against having File read and expand_path
+      # stubbed out within tests.
+      class File
+        class << self
+          [:read, :expand_path].each do |method_name|
+            define_method(method_name, &::File.method(method_name))
+          end
+        end
+      end
+
       def self.from_file(path)
         source = File.read(path)
         new(source, path)

--- a/spec/rspec/support/source_spec.rb
+++ b/spec/rspec/support/source_spec.rb
@@ -41,6 +41,11 @@ module RSpec::Support
         expect(source.path).not_to eq(path)
         expect(source.path).to end_with(path)
       end
+
+      it 'continues to work if File.read is stubbed' do
+        allow(::File).to receive(:read).and_raise
+        expect(source.lines.first).to eq('2.times do')
+      end
     end
 
     describe '#lines' do


### PR DESCRIPTION
Following on from conversation in rspec/rspec-mocks#1341 this fixes issues like rspec/rspec-support#428 when `File.read` is stubbed out and returns non standard content.