### PR TITLE
Restore original JRuby ripper suppression

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -113,8 +113,7 @@ module RSpec
         # or cannot parse source including `:if`.
         # Ripper on JRuby 9.x.x.x < 9.1.17.0 can't handle keyword arguments
         # Neither can JRuby 9.2, e.g. < 9.2.1.0
-        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.1.16.0'))
-        ripper_requirements.push(!Ruby.jruby_version.between?('9.1.999.0', '9.1.999.0'))
+        ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.2.0.0'))
       end
 
       if ripper_requirements.all?

--- a/spec/rspec/support/ruby_features_spec.rb
+++ b/spec/rspec/support/ruby_features_spec.rb
@@ -165,6 +165,9 @@ module RSpec
         end
 
         it 'returns whether Ripper is correctly implemented in the current environment' do
+          if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.1.0'
+            pending "Ripper is not supported on JRuby 9.1.17.0 despite this tests claims"
+          end
           expect(RubyFeatures.ripper_supported?).to eq(ripper_is_implemented? && ripper_works_correctly?)
         end
 


### PR DESCRIPTION
A bunch of tests elsewhere fail when this is changed, so this branch is a reversal to double check that it fixes that.