### PR TITLE
Fix expect_warn_deprecation matching any message

### DIFF
--- a/lib/rspec/support/spec/deprecation_helpers.rb
+++ b/lib/rspec/support/spec/deprecation_helpers.rb
@@ -1,35 +1,22 @@
 module RSpecHelpers
-  def expect_no_deprecation
-    expect(RSpec.configuration.reporter).not_to receive(:deprecation)
-  end
-
   def expect_deprecation_with_call_site(file, line, snippet=//)
-    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
-      expect(options[:call_site]).to include([file, line].join(':'))
-      expect(options[:deprecated]).to match(snippet)
-    end
+    expect(RSpec.configuration.reporter).to receive(:deprecation).
+      with(include(:deprecated => match(snippet), :call_site => include([file, line].join(':'))))
   end
 
   def expect_deprecation_without_call_site(snippet=//)
-    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
-      expect(options[:call_site]).to eq nil
-      expect(options[:deprecated]).to match(snippet)
-    end
+    expect(RSpec.configuration.reporter).to receive(:deprecation).
+      with(include(:deprecated => match(snippet), :call_site => eq(nil)))
   end
 
   def expect_warn_deprecation_with_call_site(file, line, snippet=//)
-    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
-      message = options[:message]
-      expect(message).to match(snippet)
-      expect(message).to include([file, line].join(':'))
-    end
+    expect(RSpec.configuration.reporter).to receive(:deprecation).
+      with(include(:message => match(snippet), :call_site => include([file, line].join(':'))))
   end
 
   def expect_warn_deprecation(snippet=//)
-    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
-      message = options[:message]
-      expect(message).to match(snippet)
-    end
+    expect(RSpec.configuration.reporter).to receive(:deprecation).
+      with(include(:message => match(snippet)))
   end
 
   def allow_deprecation
@@ -39,19 +26,16 @@ module RSpecHelpers
   def expect_no_deprecations
     expect(RSpec.configuration.reporter).not_to receive(:deprecation)
   end
+  alias expect_no_deprecation expect_no_deprecations
 
   def expect_warning_without_call_site(expected=//)
-    expect(::Kernel).to receive(:warn) do |message|
-      expect(message).to match expected
-      expect(message).to_not match(/Called from/)
-    end
+    expect(::Kernel).to receive(:warn).
+      with(match(expected).and(satisfy { |message| !(/Called from/ =~ message) }))
   end
 
   def expect_warning_with_call_site(file, line, expected=//)
-    expect(::Kernel).to receive(:warn) do |message|
-      expect(message).to match expected
-      expect(message).to match(/Called from #{file}:#{line}/)
-    end
+    expect(::Kernel).to receive(:warn).
+      with(match(expected).and(match(/Called from #{file}:#{line}/)))
   end
 
   def expect_no_warnings

--- a/spec/rspec/support/deprecation_helpers_spec.rb
+++ b/spec/rspec/support/deprecation_helpers_spec.rb
@@ -1,0 +1,101 @@
+require 'rspec/matchers/fail_matchers'
+
+RSpec.describe RSpecHelpers do
+  def deprecate!(message)
+    RSpec.configuration.reporter.deprecation(:message => message)
+  end
+
+  def fail_with(snippet)
+    raise_error(RSpec::Mocks::MockExpectationError, snippet)
+  end
+
+  def raise_unrelated_expectation!
+    raise(RSpec::Expectations::ExpectationNotMetError, 'abracadabra')
+  end
+
+  describe '#expect_no_deprecations' do
+    shared_examples_for 'expects no deprecations' do
+      it 'passes when there were no deprecations' do
+        expectation
+      end
+
+      it 'fails when there was a deprecation warning' do
+        in_sub_process do
+          expect {
+            expectation
+            deprecate!('foo')
+          }.to fail_with(/received: 1 time/)
+        end
+      end
+
+      it 'fails with a MockExpectationError when there was also an ExpectationNotMetError' do
+        in_sub_process do
+          expect {
+            expectation
+            deprecate!('bar')
+            raise_unrelated_expectation!
+          }.to fail_with(/received: 1 time/)
+        end
+      end
+    end
+
+    it_behaves_like 'expects no deprecations' do
+      def expectation
+        expect_no_deprecations
+      end
+    end
+
+    # Alias
+    it_behaves_like 'expects no deprecations' do
+      def expectation
+        expect_no_deprecation
+      end
+    end
+  end
+
+  describe '#expect_warn_deprecation' do
+    it 'passes when there was a deprecation warning' do
+      in_sub_process do
+        expect_warn_deprecation(/bar/)
+        deprecate!('bar')
+      end
+    end
+
+    pending 'fails when there were no deprecations' do
+      in_sub_process do
+        expect {
+          expect_warn_deprecation(/bar/)
+        }.to raise_error(/received: 0 times/)
+      end
+    end
+
+    it 'fails with a MockExpectationError when there was also an ExpectationNotMetError' do
+      in_sub_process do
+        expect {
+          expect_warn_deprecation(/bar/)
+          deprecate!('bar')
+          raise_unrelated_expectation!
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+    end
+
+    it 'fails when deprecation message is different' do
+      in_sub_process do
+        expect {
+          expect_warn_deprecation(/bar/)
+          deprecate!('foo')
+        }.to raise_error(%r{match /bar/})
+      end
+    end
+
+    it 'fails when deprecation message is different and an ExpectationNotMetError was raised' do
+      in_sub_process do
+        expect {
+          expect_warn_deprecation(/bar/)
+          deprecate!('foo')
+          raise_unrelated_expectation!
+        }.to raise_error(%r{match /bar/})
+      end
+    end
+  end
+end


### PR DESCRIPTION
expect_warn_deprecation matches any message when there's
raise_error(RSpec::Expectations::ExpectationNotMetError) in the example,
e.g.:

    it 'prints a deprecation warning when given a value and negated' do
      expect_warn_deprecation(/complete nonsense/)
      expect { expect(3).not_to matcher }.to fail
    end

fixes: #451

I'm sending against `main`, but it needs to be merged to `4-0-dev` as well.