### PR TITLE
Fix simplecov source file filter

### DIFF
--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -64,8 +64,8 @@ module RSpec
 
       def self.start_simplecov(&block)
         SimpleCov.start do
-          add_filter "./bundle/"
-          add_filter "./tmp/"
+          add_filter "bundle/"
+          add_filter "tmp/"
           add_filter do |source_file|
             # Filter out `spec` directory except when it is under `lib`
             # (as is the case in rspec-support)


### PR DESCRIPTION
simplecov 0.20.0 does filtering with abosulute file paths.
We were not excluding `bundle` directory.

Before (https://github.com/rspec/rspec-support/runs/1627962469)
```
Coverage report generated for RSpec to /home/runner/work/rspec-support/rspec-support/coverage. 956 / 1444 LOC (66.2%) covered.

Coverage report generated for RSpec to /home/runner/work/rspec-support/rspec-expectations/coverage. 3116 / 3596 LOC (86.65%) covered.
```

After
(https://github.com/rspec/rspec-support/pull/480/checks?check_run_id=1628102829)
```
Coverage report generated for RSpec to /home/runner/work/rspec-support/rspec-support/coverage. 519 / 544 LOC (95.4%) covered.

Coverage report generated for RSpec to /home/runner/work/rspec-support/rspec-expectations/coverage. 2767 / 2797 LOC (98.93%) covered.
```

Debug output, excerpt from `coverage/index.html`
(https://github.com/rspec/rspec-expectations/pull/1273/checks?check_run_id=1628049675):

```
<td class="strong t-file__name">...bundle/ruby/2.7.0/gems/diff-lcs-1.4.4/lib/diff/lcs.rb">bundle/ruby/2.7.0/gems/diff-lcs-1.4.4/lib/diff/lcs.rb ...</td>
<td class="red strong cell--number t-file__coverage">33.08 %</td>
```

`rspec-core` already does filtering this way https://github.com/rspec/rspec-core/blob/fe3084758857f0714f05ada44a18f1dfe9bf7a7e/script/rspec_with_simplecov#L31