### PR TITLE
Prevent JRuby build failure by sending to Kernel.require

### DIFF
--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -14,7 +14,12 @@ module RSpec
     def self.define_optimized_require_for_rspec(lib, &require_relative)
       name = "require_rspec_#{lib}"
 
-      if Kernel.respond_to?(:require_relative)
+      if RUBY_PLATFORM == 'java' && !Kernel.respond_to?(:require)
+        # JRuby 9.1.17.0 has developed a regression for require
+        (class << self; self; end).__send__(:define_method, name) do |f|
+          Kernel.send(:require, "rspec/#{lib}/#{f}")
+        end
+      elsif Kernel.respond_to?(:require_relative)
         (class << self; self; end).__send__(:define_method, name) do |f|
           require_relative.call("#{lib}/#{f}")
         end

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -13,3 +13,8 @@ else
   gem update --system '2.7.8'
   gem install bundler -v '1.17.3'
 fi
+
+echo "Setup complete"
+ruby -v
+gem -v
+bundler -v


### PR DESCRIPTION
I have no idea why this has started happening on a pre-existing version of JRuby but:

```
/home/runner/work/rspec-mocks/rspec-mocks/bin/rspec
NoMethodError: private method `require' called for Kernel:Module
Did you mean?  java_require
                require_relative at uri:classloader:/jruby/kernel/kernel.rb:13
                block in Support at /home/runner/work/rspec-mocks/rspec-mocks/bundle/jruby/2.3.0/bundler/gems/rspec-support-cb494ebc9ce9/lib/rspec/support.rb:28
```

Some Googling suggests this was once upon a problem for JRuby 1.7 but 😕 