### PR TITLE
Verify partial doubles by default, take 2

### DIFF
--- a/spec/rspec/support/recursive_const_methods_spec.rb
+++ b/spec/rspec/support/recursive_const_methods_spec.rb
@@ -12,7 +12,7 @@ module RSpec
 
         class Bar < Parent
           VAL = 10
-          def to_str
+          def self.to_str
             "Bar"
           end
         end


### PR DESCRIPTION
Follow-up to #494, fixes a spec that failed partial double verification