### PR TITLE
Use Mutex#owned? to correctly check if the Mutex is owned by the current Thread or Fiber

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Breaking Changes:
 
 * Ruby < 2.3 is no longer supported. (Phil Pirozhkov, #436)
 
+Bug Fixes:
+* Fix reentrant mutex for Ruby 3.0. (Benoit Daloze, #503)
+
 ### 3.10.0 / 2020-10-30
 
 No changes. Released to support other RSpec releases.

--- a/spec/rspec/support/reentrant_mutex_spec.rb
+++ b/spec/rspec/support/reentrant_mutex_spec.rb
@@ -34,4 +34,28 @@ RSpec.describe RSpec::Support::ReentrantMutex do
     mutex.synchronize { order.pass_to :thread, :resume_on => :sleep }
     order.join_all
   end
+
+  if RUBY_VERSION >= '3.0'
+    it 'waits when trying to lock from another Fiber' do
+      mutex.synchronize do
+        ready = false
+        f = Fiber.new do
+          expect {
+            ready = true
+            mutex.send(:enter)
+            raise 'should reach here: mutex is already locked on different Fiber'
+          }.to raise_error(Exception, 'waited correctly')
+        end
+
+        main_thread = Thread.current
+
+        t = Thread.new do
+          Thread.pass until ready and main_thread.stop?
+          main_thread.raise Exception, 'waited correctly'
+        end
+        f.resume
+        t.join
+      end
+    end
+  end
 end


### PR DESCRIPTION
* In Ruby >= 3, Mutex are held per Fiber, not per Thread.
* Fixes https://github.com/rspec/rspec-support/issues/501

Based on https://github.com/rspec/rspec-support/pull/502#issuecomment-826896692
Seems a better alternative to https://github.com/rspec/rspec-support/pull/502.