### PR TITLE
Use Mutex#owned? to correctly check if the Mutex is owned by the current Thread or Fiber

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### Development
+
+Bug Fixes:
+* Fix reentrant mutex for Ruby 3.0. (Benoit Daloze, #504)
+
 ### 3.10.2 / 2021-01-28
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.10.1...v3.10.2)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,9 @@
 ### Development
 
 Bug Fixes:
-* Fix reentrant mutex for Ruby 3.0. (Benoit Daloze, #504)
+
+* Use `Mutex#owned?` to allow `RSpec::Support::ReentrantMutex` to work in
+  nested Fibers on Ruby 3.0 and later. (Benoit Daloze, #503, #504)
 
 ### 3.10.2 / 2021-01-28
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.10.1...v3.10.2)


### PR DESCRIPTION
In Ruby >= 3, Mutex are held per Fiber, not per Thread.

Fixes #501

This is a backport of #503 for RSpec 3