### PR TITLE
allow inspectors to be registered for different objects

### DIFF
--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -276,7 +276,7 @@ module RSpec
             raise ArgumentError, 'provided inspector does not respond to can_inspect?'
           end
 
-          @inspectors.prepend(inspector)
+          @inspectors.unshift(inspector)
         end
 
         def find_for(object)

--- a/spec/rspec/support/object_formatter_spec.rb
+++ b/spec/rspec/support/object_formatter_spec.rb
@@ -418,11 +418,14 @@ module RSpec
         end
 
         let(:input) do
-          { :key1 => TimeObjectTest.new(1, 30), :key2 => TimeObjectTest.new(0, 90) }
+          [
+            { :key => TimeObjectTest.new(1, 30) },
+            { :key => TimeObjectTest.new(0, 90) }
+          ]
         end
 
         it "uses the custom inspector" do
-          expect(output).to eq('{:key1=>90, :key2=>90}')
+          expect(output).to eq('[{:key=>90}, {:key=>90}]')
         end
       end
     end


### PR DESCRIPTION
### Subject of the issue
When comparing objects nested in diffable objects (e.g. `Hash`), it can be difficult to differentiate
between objects which are failing the comparison and objects which are considered equal but
have different outputs for `inspect`. One notable example is `ActiveSupport::Duration` where
`60.minutes` is considered equivalent to `1.hour`, but produces different output for `inspect`
which can cause confusion and seem like it is failing the assertion when it is in fact just failing the
inspect comparison.

The proposal is to allow inspectors to be registered in `ObjectFormatter` so that custom
inspectors can be added for these classes, to improve the signal to noise ratio in diffs
when looking at failed tests.

At the moment it is possible to 'hack' this by manually prepending a custom inspector class
to `RSpec::Support::ObjectFormatter::INSPECTOR_CLASSES`, but here we create a more
friendly interface to allow this through something like:
```ruby
RSpec::Support::ObjectFormatter.inspectors.register(CustomInspector)
```
If this gains enough traction this could be expanded to allow for configuring this in
RSpec's configuration, perhaps in a similar way to what is mentioned [here](https://github.com/rspec/rspec/issues/76).

Related to https://github.com/rspec/rspec/issues/76

### Your environment
* Ruby version: ruby 2.7.3p183
* rspec-support version: 3.11.0.pre

### Steps to reproduce
To see an example of failing specs which provide misleading diffs, run this example and
note how in the `'does not show in the diff when objects are equivalent'` example it seems
that both `object1` and `object2` are failing the assertion, when in fact only `object2`
is failing the assertion.
```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "rspec", "3.10.0" # Activate the gem and version you are reporting the issue against.
end

puts "Ruby version is: #{RUBY_VERSION}"
require 'rspec/autorun'

class TimeParts
  SECONDS_PER_MINUTE = 60

  def initialize(minutes, seconds)
    @minutes = minutes
    @seconds = seconds
  end

  def to_i
    (@minutes * SECONDS_PER_MINUTE) + @seconds
  end

  def inspect
    "#{@minutes} minutes and #{@seconds} seconds"
  end

  def ==(other)
    self.to_i == other.to_i
  end

  alias_method :eql?, :==

  def hash
    [@minutes, @seconds].hash
  end
end

RSpec.describe TimeParts do
  it 'considers equavilent objects equal' do
    object1 = TimeParts.new(1, 30)
    object2 = TimeParts.new(0, 90)
    expect(object1).to eq(object2)
  end

  it 'does not show in the diff when objects have the same result from inspect' do
    hash1 = {
      object1: TimeParts.new(0, 90),
      object2: TimeParts.new(0, 90)
    }
    hash2 = {
      object1: TimeParts.new(0, 90),
      object2: TimeParts.new(1, 90)
    }
    expect(hash1).to eq(hash2)
  end

  it 'does not show in the diff when objects are equivalent' do
    hash1 = {
      object1: TimeParts.new(1, 30),
      object2: TimeParts.new(0, 90)
    }
    hash2 = {
      object1: TimeParts.new(0, 90),
      object2: TimeParts.new(1, 90)
    }
    expect(hash1).to eq(hash2)
  end
end
```

### Expected behavior
We should be able to register a custom inspector, to be able to modify the output of inspect
for specific objects, so that it becomes easier to tell what is actually failing the assertion:
```ruby
class TimePartsInspector < ObjectFormatter::BaseInspector
  def self.can_inspect?(object)
    TimeParts === object
  end

  def inspect
    object.to_i.inspect
  end
end

RSpec::Support::ObjectFormatter.inspectors.register(TimePartsInspector)
```
This would mean that after registering the custom inspector above, the diff would look like this:
```
Failure/Error: expect(hash1).to eq(hash2)

  expected: {:object1=>90, :object2=>150}
       got: {:object1=>90, :object2=>90}

  (compared using ==)

  Diff:
  @@ -1,3 +1,3 @@
   :object1 => 90,
  -:object2 => 150,
  +:object2 => 90,
```

### Actual behavior

Diffs are based on the raw outoput of `inspect`, so it is hard to tell that the value in `object1`
is not actually failing the assertion, and that only the value in `object2` is the issue:
```
Failure/Error: expect(hash1).to eq(hash2)

  expected: {:object1=>0 minutes and 90 seconds, :object2=>1 minutes and 90 seconds}
       got: {:object1=>1 minutes and 30 seconds, :object2=>0 minutes and 90 seconds}

  (compared using ==)

  Diff:
  @@ -1,3 +1,3 @@
  -:object1 => 0 minutes and 90 seconds,
  -:object2 => 1 minutes and 90 seconds,
  +:object1 => 1 minutes and 30 seconds,
  +:object2 => 0 minutes and 90 seconds,
```
