### PR TITLE
Disable ripper in TruffleRuby due to slow performance

### DIFF
--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -116,6 +116,9 @@ module RSpec
         ripper_requirements.push(!Ruby.jruby_version.between?('9.0.0.0.rc1', '9.2.0.0'))
       end
 
+      # TruffleRuby disables ripper due to low perforamnce
+      ripper_requirements.push(false) if Ruby.truffleruby?
+
       if ripper_requirements.all?
         def ripper_supported?
           true


### PR DESCRIPTION
From comment:
https://github.com/rspec/rspec-metagem/issues/68#issuecomment-1098037326

> I think we should disable the usage of Ripper by RSpec for TruffleRuby, in practice it seems currently very slow (seconds of pause just before showing errors & backtraces) and so it hurts the user experience a lot more than help.

cc @eregon 