### PR TITLE
Add Ruby 3.2 to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - 2.7


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
`ruby-head` now tracks 3.3