### PR TITLE
Prevent warnings about encoding from preventing transfer of errors

### DIFF
--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -11,6 +11,10 @@ module RSpec
           exception_reader, exception_writer = IO.pipe
           result_reader, result_writer = IO.pipe
 
+          # Set binary mode to avoid errors surrounding ascii-8bit to utf-8 conversion
+          # this happens with warnings on rspec-rails for example
+          [exception_reader, exception_writer, result_reader, result_writer].each { |io| io.binmode }
+
           pid = Process.fork do
             warning_preventer = $stderr = RSpec::Support::StdErrSplitter.new($stderr)
 


### PR DESCRIPTION
With `rspec-rails` using `in_sub_process` regularly masks errors by causing this internal error:

```
DEPRECATION WARNING: some output
 (called from block (3 levels) in <top (required)> at /home/runner/work/rspec-rails/rspec-rails/spec/rspec/rails/configuration_spec.rb:168)
/home/runner/work/rspec-rails/rspec-support/lib/rspec/support/spec/in_sub_process.rb:25:in `write': "\x98" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
```

Which in turn masks the error as:

```
ArgumentError:
       marshal data too short
```

This fixes that and raises the proper error (in this case about the warnings about being present)

I tried to write a test for this but the encoding worked with all the invalid samples I can come up with, if someone can create one please feel free to add it.