### PR TITLE
Reduce memory usage by using frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,9 @@ Lint/AssignmentInCondition:
   Exclude:
     # The pattern makes sense here
     - 'lib/rspec/support/mutex.rb'
+
+Style/FrozenStringLiteralComment:
+  Include:
+    - lib/**/*.rb
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -307,13 +307,6 @@ Style/FormatString:
   Exclude:
     - 'spec/rspec/support/encoded_string_spec.rb'
 
-# Offense count: 68
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/GlobalStdStream:

--- a/lib/rspec/support.rb
+++ b/lib/rspec/support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # @api private

--- a/lib/rspec/support/caller_filter.rb
+++ b/lib/rspec/support/caller_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support "ruby_features"
 
 module RSpec

--- a/lib/rspec/support/comparable_version.rb
+++ b/lib/rspec/support/comparable_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'hunk_generator'
 RSpec::Support.require_rspec_support "object_formatter"

--- a/lib/rspec/support/directory_maker.rb
+++ b/lib/rspec/support/directory_maker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'ruby_features'
 
 module RSpec

--- a/lib/rspec/support/encoded_string.rb
+++ b/lib/rspec/support/encoded_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/fuzzy_matcher.rb
+++ b/lib/rspec/support/fuzzy_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # Provides a means to fuzzy-match between two arbitrary objects.

--- a/lib/rspec/support/hunk_generator.rb
+++ b/lib/rspec/support/hunk_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'diff/lcs'
 require 'diff/lcs/hunk'
 

--- a/lib/rspec/support/matcher_definition.rb
+++ b/lib/rspec/support/matcher_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # @private

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support'
 RSpec::Support.require_rspec_support "ruby_features"
 RSpec::Support.require_rspec_support "matcher_definition"

--- a/lib/rspec/support/mutex.rb
+++ b/lib/rspec/support/mutex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # On 1.8.7, it's in the stdlib.

--- a/lib/rspec/support/object_formatter.rb
+++ b/lib/rspec/support/object_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'matcher_definition'
 
 module RSpec

--- a/lib/rspec/support/recursive_const_methods.rb
+++ b/lib/rspec/support/recursive_const_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # Provides recursive constant lookup methods useful for

--- a/lib/rspec/support/reentrant_mutex.rb
+++ b/lib/rspec/support/reentrant_mutex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     # Allows a thread to lock out other threads from a critical section of code,

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 RSpec::Support.require_rspec_support "comparable_version"
 

--- a/lib/rspec/support/source.rb
+++ b/lib/rspec/support/source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'encoded_string'
 RSpec::Support.require_rspec_support 'ruby_features'
 

--- a/lib/rspec/support/source/location.rb
+++ b/lib/rspec/support/source/location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     class Source

--- a/lib/rspec/support/source/node.rb
+++ b/lib/rspec/support/source/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'source/location'
 
 module RSpec

--- a/lib/rspec/support/source/token.rb
+++ b/lib/rspec/support/source/token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support 'source/location'
 
 module RSpec

--- a/lib/rspec/support/spec.rb
+++ b/lib/rspec/support/spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support'
 require 'rspec/support/spec/in_sub_process'
 

--- a/lib/rspec/support/spec/deprecation_helpers.rb
+++ b/lib/rspec/support/spec/deprecation_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpecHelpers
   def expect_deprecation_with_call_site(file, line, snippet=//)
     expect(RSpec.configuration.reporter).to receive(:deprecation).

--- a/lib/rspec/support/spec/diff_helpers.rb
+++ b/lib/rspec/support/spec/diff_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'diff/lcs'
 
 module RSpec

--- a/lib/rspec/support/spec/formatting_support.rb
+++ b/lib/rspec/support/spec/formatting_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     module FormattingSupport

--- a/lib/rspec/support/spec/in_sub_process.rb
+++ b/lib/rspec/support/spec/in_sub_process.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     module InSubProcess

--- a/lib/rspec/support/spec/library_wide_checks.rb
+++ b/lib/rspec/support/spec/library_wide_checks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support/spec/shell_out'
 
 module RSpec

--- a/lib/rspec/support/spec/shell_out.rb
+++ b/lib/rspec/support/spec/shell_out.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'rake/file_utils'
 require 'shellwords'

--- a/lib/rspec/support/spec/stderr_splitter.rb
+++ b/lib/rspec/support/spec/stderr_splitter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 module RSpec

--- a/lib/rspec/support/spec/string_matcher.rb
+++ b/lib/rspec/support/spec/string_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/matchers'
 # Special matcher for comparing encoded strings so that
 # we don't run any expectation failures through the Differ,

--- a/lib/rspec/support/spec/with_isolated_directory.rb
+++ b/lib/rspec/support/spec/with_isolated_directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 
 RSpec.shared_context "isolated directory" do

--- a/lib/rspec/support/spec/with_isolated_stderr.rb
+++ b/lib/rspec/support/spec/with_isolated_stderr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     module WithIsolatedStdErr

--- a/lib/rspec/support/version.rb
+++ b/lib/rspec/support/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Support
     module Version

--- a/lib/rspec/support/warnings.rb
+++ b/lib/rspec/support/warnings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support'
 RSpec::Support.require_rspec_support "caller_filter"
 

--- a/lib/rspec/support/with_keywords_when_needed.rb
+++ b/lib/rspec/support/with_keywords_when_needed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_support("method_signature_verifier")
 
 module RSpec


### PR DESCRIPTION
I was running memory_profiler on a spec with a large number of examples (950), and it surfaced several places in rspec-support that aren't using frozen strings.

Originally, it was `::` in `lib/rspec/support/recursive_const_methods.rb` that caught my attention, but I figure it can be enabled everywhere.

I did not enable it for specs, because I figure that wouldn't have as much impact since it would only affect rspec-support's specs.

I'll include some memory_profile details in the comments.