### PR TITLE
Allow string keys for method kwarg splats

### DIFF
--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -84,7 +84,7 @@ module RSpec
         def has_kw_args_in?(args)
           Hash === args.last &&
             could_contain_kw_args?(args) &&
-            (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
+            (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) || x.is_a?(String) })
         end
 
         # Without considering what the last arg is, could it
@@ -365,12 +365,12 @@ module RSpec
       def split_args(*args)
         kw_args = if @signature.has_kw_args_in?(args)
                     last = args.pop
-                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) }
+                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) || k.is_a?(String) }
                     if non_kw_args.empty?
                       last.keys
                     else
                       args << non_kw_args
-                      last.select { |k, _| k.is_a?(Symbol) }.keys
+                      last.select { |k, _| k.is_a?(Symbol) || k.is_a(String) }.keys
                     end
                   else
                     []

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -364,14 +364,7 @@ module RSpec
 
       def split_args(*args)
         kw_args = if @signature.has_kw_args_in?(args)
-                    last = args.pop
-                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) || k.is_a?(String) }
-                    if non_kw_args.empty?
-                      last.keys
-                    else
-                      args << non_kw_args
-                      last.select { |k, _| k.is_a?(Symbol) || k.is_a(String) }.keys
-                    end
+                    args.pop.select { |k, _| k.is_a?(Symbol) || k.is_a?(String) }.keys
                   else
                     []
                   end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -84,7 +84,7 @@ module RSpec
         def has_kw_args_in?(args)
           Hash === args.last &&
             could_contain_kw_args?(args) &&
-            (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) || x.is_a?(String) })
+            (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) || RubyFeatures.kw_arg_separation? })
         end
 
         # Without considering what the last arg is, could it
@@ -364,7 +364,14 @@ module RSpec
 
       def split_args(*args)
         kw_args = if @signature.has_kw_args_in?(args)
-                    args.pop.select { |k, _| k.is_a?(Symbol) || k.is_a?(String) }.keys
+                    last = args.pop
+                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) || RubyFeatures.kw_arg_separation? }
+                    if non_kw_args.empty?
+                      last.keys
+                    else
+                      args << non_kw_args
+                      last.select { |k, _| k.is_a?(Symbol) || RubyFeatures.kw_arg_separation? }.keys
+                    end
                   else
                     []
                   end

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -84,7 +84,7 @@ module RSpec
         def has_kw_args_in?(args)
           Hash === args.last &&
             could_contain_kw_args?(args) &&
-            (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) || RubyFeatures.kw_arg_separation? })
+            (RubyFeatures.kw_arg_separation? || args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
         end
 
         # Without considering what the last arg is, could it
@@ -363,15 +363,17 @@ module RSpec
       end
 
       def split_args(*args)
-        kw_args = if @signature.has_kw_args_in?(args)
+        kw_args = if @signature.has_kw_args_in?(args) && !RubyFeatures.kw_arg_separation?
                     last = args.pop
-                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) || RubyFeatures.kw_arg_separation? }
+                    non_kw_args = last.reject { |k, _| k.is_a?(Symbol) }
                     if non_kw_args.empty?
                       last.keys
                     else
                       args << non_kw_args
-                      last.select { |k, _| k.is_a?(Symbol) || RubyFeatures.kw_arg_separation? }.keys
+                      last.select { |k, _| k.is_a?(Symbol) }.keys
                     end
+                  elsif @signature.has_kw_args_in?(args) && RubyFeatures.kw_arg_separation?
+                    args.pop.keys
                   else
                     []
                   end

--- a/lib/rspec/support/ruby_features.rb
+++ b/lib/rspec/support/ruby_features.rb
@@ -106,6 +106,17 @@ module RSpec
         end
       end
 
+      if RUBY_VERSION.to_f >= 3.0
+        # https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments
+        def kw_arg_separation?
+          true
+        end
+      else
+        def kw_arg_separation?
+          false
+        end
+      end
+
       if RUBY_VERSION.to_f >= 2.7
         def supports_taint?
           false

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -679,9 +679,9 @@ module RSpec
             end
 
             it "ignores kwargs with invalid types if there are any with valid types" do
-              expect(valid?(:x => 1, 3 => 10, {"a":"b"} => 1)).to eq(true)
-              expect(valid?(:x => 1, 'y' => 2, 3 => 10, {"a":"b"} => 1)).to eq(true)
-              expect(valid?('y' => 2, 3 => 10, {"a":"b"} => 1)).to eq(true)
+              expect(valid?(:x => 1, 3 => 10)).to eq(true)
+              expect(valid?(:x => 1, 'y' => 2, 3 => 10)).to eq(true)
+              expect(valid?('y' => 2, 3 => 10)).to eq(true)
             end
 
             it 'mentions the required kw args and keyword splat in the description' do

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -670,6 +670,18 @@ module RSpec
             it 'allows undeclared keyword args' do
               expect(valid?(:x => 1)).to eq(true)
               expect(valid?(:x => 1, 'y' => 2)).to eq(true)
+              expect(valid?('y' => 2)).to eq(true)
+            end
+
+            it 'does not allow kw args of only unsupported types' do
+              expect(valid?(3 => 1)).to eq(false)
+              expect(valid?({"a":"b"} => 1)).to eq(false)
+            end
+
+            it "ignores kwargs with invalid types if there are any with valid types" do
+              expect(valid?(:x => 1, 3 => 10, {"a":"b"} => 1)).to eq(true)
+              expect(valid?(:x => 1, 'y' => 2, 3 => 10, {"a":"b"} => 1)).to eq(true)
+              expect(valid?('y' => 2, 3 => 10, {"a":"b"} => 1)).to eq(true)
             end
 
             it 'mentions the required kw args and keyword splat in the description' do

--- a/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/spec/rspec/support/method_signature_verifier_spec.rb
@@ -384,17 +384,21 @@ module RSpec
               expect(valid?(nil, :a => 1)).to eq(false)
             end
 
-            it 'treats symbols as keyword arguments and the rest as optional argument' do
-              expect(valid?(nil, 'a' => 1)).to eq(true)
-              expect(valid?(nil, 'a' => 1, :z => 3)).to eq(true)
-              expect(valid?(nil, 'a' => 1, :b => 3)).to eq(false)
-              expect(valid?(nil, 'a' => 1, :b => 2, :z => 3)).to eq(false)
+            it 'treats symbols as keyword arguments' do
+              expect(valid?(nil, :z => 3)).to eq(true)
+              expect(valid?(nil, :b => 3)).to eq(false)
+              expect(valid?(nil, :b => 2, :z => 3)).to eq(false)
+            end
+
+            it 'treats string keys as invalid keyword arguments' do
+              expect(valid?(nil, 'a' => 1)).to eq(false)
+              expect(valid?(nil, 'a' => 1, :z => 3)).to eq(false)
             end
 
             it 'mentions the invalid keyword args in the error', :pending => RSpec::Support::Ruby.jruby? && !RSpec::Support::Ruby.jruby_9000? do
               expect(error_for(1, 2, :a => 0)).to eq("Invalid keyword arguments provided: a")
               expect(error_for(1, :a => 0)).to eq("Invalid keyword arguments provided: a")
-              expect(error_for(1, 'a' => 0, :b => 0)).to eq("Invalid keyword arguments provided: b")
+              expect(error_for(1, 'a' => 0, :b => 0)).to eq("Invalid keyword arguments provided: a, b")
             end
 
             it 'describes invalid arity precisely' do
@@ -656,6 +660,41 @@ module RSpec
             end
           end
 
+          describe 'a method with only a keyword arg splat' do
+            eval <<-RUBY
+              def arity_kw_arg_splat(**rest); end
+            RUBY
+
+            let(:test_method) { method(:arity_kw_arg_splat) }
+
+            it 'allows undeclared keyword args' do
+              expect(valid?(:x => 1)).to eq(true)
+              expect(valid?(:x => 1, 'y' => 2)).to eq(true)
+            end
+
+            it 'mentions the required kw args and keyword splat in the description' do
+              expect(signature_description).to \
+                eq("any additional keyword args")
+            end
+
+            describe 'with an expectation object' do
+              it 'allows zero non-kw args' do
+                expect(validate_expectation 0).to eq(true)
+                expect(validate_expectation 1).to eq(false)
+                expect(validate_expectation 0, 0).to eq(true)
+                expect(validate_expectation 0, 1).to eq(false)
+              end
+
+              it 'does not match unlimited arguments' do
+                expect(validate_expectation :unlimited_args).to eq(false)
+              end
+
+              it 'matches arbitrary keywords' do
+                expect(validate_expectation :arbitrary_kw_args).to eq(true)
+              end
+            end
+          end
+
           describe 'a method with required keyword arguments and a keyword arg splat' do
             eval <<-RUBY
               def arity_kw_arg_splat(x:, **rest); end
@@ -666,6 +705,7 @@ module RSpec
             it 'allows extra undeclared keyword args' do
               expect(valid?(:x => 1)).to eq(true)
               expect(valid?(:x => 1, :y => 2)).to eq(true)
+              expect(valid?(:x => 1, :y => 2, 'z' => 3)).to eq(true)
             end
 
             it 'mentions missing required keyword args in the error' do
@@ -730,7 +770,9 @@ module RSpec
             it 'allows a single arg and any number of keyword args' do
               expect(valid?(nil)).to eq(true)
               expect(valid?(nil, :x => 1)).to eq(true)
+              expect(valid?(nil, 'x' => 1)).to eq(true)
               expect(valid?(nil, :x => 1, :y => 2)).to eq(true)
+              expect(valid?(nil, :x => 1, :y => 2, 'z' => 3)).to eq(true)
               expect(valid?(:x => 1)).to eq(true)
               expect(valid?(nil, {})).to eq(true)
 


### PR DESCRIPTION
Attempting to fix: https://github.com/rspec/rspec-support/issues/554

The change expands the matching criteria for kwargs from `x.is_a?(Symbol)` to `x.is_a?(Symbol) || x.is_a?(String)`.  This now properly mirrors the behavior in the ruby docs.

https://docs.ruby-lang.org/en/3.0/syntax/calling_methods_rdoc.html#label-Hash+to+Keyword+Arguments+Conversion

Elsewhere tests were asserting that args with string keys were treated as optional arguments.  I have not tested if this is true for ruby prior to ruby 3, but this is NOT true for ruby 3, and I've adjusted those tests.

**Testing**
```
bundle exec rspec spec/rspec/support/method_signature_verifier_spec.rb
...
Finished in 0.03491 seconds (files took 0.09141 seconds to load)
268 examples, 0 failures
```
Running script/run_build fails with a permissions error during rspec, so I don't have a clean test pass of the whole repo.