### PR TITLE
various: fix miscellaneous typos

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -130,7 +130,7 @@ Bug Fixes:
 Bug Fixes:
 
 * Ensure that inspecting a `SimpleDelegator` based object works regardless of
-  visibilty of the `__getobj__` method. (Jon Rowe, #369)
+  visibility of the `__getobj__` method. (Jon Rowe, #369)
 
 ### 3.8.0 / 2018-08-04
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.7.1...v3.8.0)
@@ -238,7 +238,7 @@ Changes:
 
 Enhancements:
 
-* Improve formatting of `Delegator` based objects (e.g. `SimpleDelgator`) in
+* Improve formatting of `Delegator` based objects (e.g. `SimpleDelegator`) in
   failure messages and diffs. (Andrew Horner, #215)
 * Add `ComparableVersion`. (Yuji Nakayama, #245)
 * Add `Ripper` support detection. (Yuji Nakayama, #245)

--- a/benchmarks/caller_vs_caller_locations_vs_raise.rb
+++ b/benchmarks/caller_vs_caller_locations_vs_raise.rb
@@ -1,5 +1,5 @@
 # This benchmark arose from rspec/rspec-support#199 where we experimented with
-# faster ways of generating / capturing a backtrace and wether it made sense
+# faster ways of generating / capturing a backtrace and whether it made sense
 # to lazily generate it using `raise` to capture the backtrace via an exception.
 # See also rspec/rspec-mocks#937
 

--- a/lib/rspec/support/method_signature_verifier.rb
+++ b/lib/rspec/support/method_signature_verifier.rb
@@ -380,7 +380,7 @@ module RSpec
       end
     end
 
-    # Figures out wether a given method can accept various arguments.
+    # Figures out whether a given method can accept various arguments.
     # Surprisingly non-trivial.
     #
     # @private

--- a/lib/rspec/support/reentrant_mutex.rb
+++ b/lib/rspec/support/reentrant_mutex.rb
@@ -64,7 +64,7 @@ module RSpec
       # On 1.9 and up, this is in core, so we just use the real one
       class Mutex < ::Mutex
         # If you mock Mutex.new you break our usage of Mutex, so
-        # instead we capture the original method to return Mutexs.
+        # instead we capture the original method to return Mutexes.
         NEW_MUTEX_METHOD = Mutex.method(:new)
 
         def self.new


### PR DESCRIPTION
This PR aims to fix various minor typos across the codebase. I noticed some of these when doing the same review on our Homebrew/brew repo, since we use spec-support.