### PR TITLE
Fixes diff when fuzzy finder `anything` is used in a Hash object (proof of concept)

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -17,13 +17,9 @@ module RSpec
 
         unless actual.nil? || expected.nil?
           if all_strings?(actual, expected)
-            if any_multiline_strings?(actual, expected)
-              diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
-            end
+            diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected)) if any_multiline_strings?(actual, expected)
           elsif hash_with_anything?(expected)
-            if no_procs_no_numbers.call(actual, expected)
-              diff = diff_as_object_with_anything(actual, expected)
-            end
+            diff = diff_as_object_with_anything(actual, expected) if no_procs_no_numbers.call(actual, expected)
           elsif no_procs_no_numbers.call(actual, expected)
             diff = diff_as_object(actual, expected)
           end

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -11,21 +11,9 @@ module RSpec
     # rubocop:disable Metrics/ClassLength
     class Differ
       def diff(actual, expected)
-        diff = ""
+        return "" if actual.nil? && expected.nil?
 
-        no_procs_no_numbers = lambda {|var1, var2| no_procs?(var1, var2) && no_numbers?(var1, var2)}
-
-        unless actual.nil? || expected.nil?
-          if all_strings?(actual, expected)
-            diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected)) if any_multiline_strings?(actual, expected)
-          elsif (keys = all_keys_from_hash(expected)) && keys.any?
-            diff = diff_as_object_with_anything(keys, actual, expected) if no_procs_no_numbers.call(actual, expected)
-          elsif no_procs_no_numbers.call(actual, expected)
-            diff = diff_as_object(actual, expected)
-          end
-        end
-
-        diff.to_s
+        run(actual, expected)
       end
 
       # rubocop:disable Metrics/MethodLength
@@ -88,6 +76,21 @@ module RSpec
       end
 
     private
+      def run(actual, expected)
+        diff = ""
+
+        no_procs_no_numbers = lambda {|var1, var2| no_procs?(var1, var2) && no_numbers?(var1, var2)}
+
+        if all_strings?(actual, expected)
+          diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected)) if any_multiline_strings?(actual, expected)
+        elsif (keys = all_keys_from_hash(expected)) && keys.any?
+          diff = diff_as_object_with_anything(keys, actual, expected) if no_procs_no_numbers.call(actual, expected)
+        elsif no_procs_no_numbers.call(actual, expected)
+          diff = diff_as_object(actual, expected)
+        end
+
+        diff.to_s
+      end
 
       def all_keys_from_hash(arg)
         return false unless Hash === arg

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -18,8 +18,8 @@ module RSpec
         unless actual.nil? || expected.nil?
           if all_strings?(actual, expected)
             diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected)) if any_multiline_strings?(actual, expected)
-          elsif hash_with_anything?(expected)
-            diff = diff_as_object_with_anything(actual, expected) if no_procs_no_numbers.call(actual, expected)
+          elsif (keys = all_keys_from_hash(expected)) && keys.any?
+            diff = diff_as_object_with_anything(keys, actual, expected) if no_procs_no_numbers.call(actual, expected)
           elsif no_procs_no_numbers.call(actual, expected)
             diff = diff_as_object(actual, expected)
           end
@@ -58,8 +58,8 @@ module RSpec
       end
       # rubocop:enable Metrics/MethodLength
 
-      def diff_as_object_with_anything(actual, expected)
-        @keys_with_anything.each do |keys|
+      def diff_as_object_with_anything(total_keys, actual, expected)
+        total_keys.each do |keys|
           pointer_expected = expected
           pointer_actual = actual
           final_key = keys.pop
@@ -89,11 +89,10 @@ module RSpec
 
     private
 
-      def hash_with_anything?(arg)
+      def all_keys_from_hash(arg)
         return false unless Hash === arg
 
-        @keys_with_anything = recursive_get_keys(arg)
-        @keys_with_anything.any?
+        recursive_get_keys(arg)
       end
 
       def recursive_get_keys(hash)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -97,9 +97,10 @@ module RSpec
       end
 
       def recursive_get_keys(hash)
-        klass = RSpec::Mocks::ArgumentMatchers::AnyArgMatcher
+        return [] unless defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
+
         hash.reduce([]) do |acc, pair|
-          if klass === pair[1]
+          if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === pair[1]
             acc << [pair[0]]
           else
             if Hash === pair[1]

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -13,16 +13,18 @@ module RSpec
       def diff(actual, expected)
         diff = ""
 
+        no_procs_no_numbers = lambda {|var1, var2| no_procs?(var1, var2) && no_numbers?(var1, var2)}
+
         unless actual.nil? || expected.nil?
           if all_strings?(actual, expected)
             if any_multiline_strings?(actual, expected)
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
             end
           elsif hash_with_anything?(expected)
-            if no_procs?(actual, expected) && no_numbers?(actual, expected)
+            if no_procs_no_numbers.call(actual, expected)
               diff = diff_as_object_with_anything(actual, expected)
             end
-          elsif no_procs?(actual, expected) && no_numbers?(actual, expected)
+          elsif no_procs_no_numbers.call(actual, expected)
             diff = diff_as_object(actual, expected)
           end
         end

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -105,7 +105,7 @@ module RSpec
             if Hash === pair[1]
               keys = recursive_get_keys(pair[1])
               keys.each do |key|
-                key.prepend pair[0]
+                key.unshift pair[0]
                 acc << key
               end
             end

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -18,7 +18,7 @@ module RSpec
             if any_multiline_strings?(actual, expected)
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
             end
-          elsif Hash === expected && hash_with_anything?(expected)
+          elsif hash_with_anything?(expected)
             if no_procs?(actual, expected) && no_numbers?(actual, expected)
               diff = diff_as_object_with_anything(actual, expected)
             end
@@ -92,6 +92,8 @@ module RSpec
     private
 
       def hash_with_anything?(arg)
+        return false unless Hash === arg
+
         @keys_with_anything = recursive_get_keys(arg)
         @keys_with_anything.any?
       end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -555,6 +555,24 @@ module RSpec
             expect(differ.diff(false, true)).to_not be_empty
           end
         end
+
+        describe "fuzzy matcher anything" do
+          it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+            actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+            expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
+            diff = differ.diff(actual, expected)
+            expected_diff = dedent(<<-'EOD')
+              |
+              |@@ -1,4 +1,4 @@
+              | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
+              | :fixed => "fixed",
+              |-:trigger => "wrong",
+              |+:trigger => "trigger",
+              |
+            EOD
+            expect(diff).to be_diffed_as(expected_diff)
+          end
+        end
       end
     end
   end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -572,6 +572,54 @@ module RSpec
             EOD
             expect(diff).to be_diffed_as(expected_diff)
           end
+
+          context "with nested hash" do
+            it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+              actual = { :an_key => "dummy", :fixed => "fixed", :nested => { :name => "foo", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" } }
+              expected = { :an_key => anything, :fixed => "fixed", :nested => { :name => "foo", :trigger => "wrong", :anything_key => anything } }
+              diff = differ.diff(actual, expected)
+              expected_diff = dedent(<<-'EOD')
+                |
+                |@@ -1,4 +1,4 @@
+                | :an_key => "dummy",
+                | :fixed => "fixed",
+                |-:nested => {:anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name=>"foo", :trigger=>"wrong"},
+                |+:nested => {:anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name=>"foo", :trigger=>"trigger"},
+                |
+              EOD
+              expect(diff).to be_diffed_as(expected_diff)
+            end
+          end
+
+          context "with nested hash and subnested hash" do
+            it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+              actual = {
+                :an_key => "dummy", :fixed => "fixed",
+                :nested => {
+                  :nested_anything_key => "9930ddcb-1cfe-4de1-a481-ca6b17d41ed8",
+                  :subnested => { :name => "foo", :trigger => "trigger", :subnested_anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+                }
+              }
+              expected = {
+                :an_key => anything, :fixed => "fixed",
+                :nested => {
+                  :nested_anything_key => anything,
+                  :subnested => { :name => "foo", :trigger => "wrong", :subnested_anything_key => anything }
+                }
+              }
+              diff = differ.diff(actual, expected)
+              expected_diff = dedent(<<-'EOD')
+                |
+                |@@ -1,4 +1,4 @@
+                | :an_key => "dummy",
+                | :fixed => "fixed",
+                |-:nested => {:nested_anything_key=>"9930ddcb-1cfe-4de1-a481-ca6b17d41ed8", :subnested=>{:name=>"foo", :subnested_anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :trigger=>"wrong"}},
+                |+:nested => {:nested_anything_key=>"9930ddcb-1cfe-4de1-a481-ca6b17d41ed8", :subnested=>{:name=>"foo", :subnested_anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :trigger=>"trigger"}},
+                |
+              EOD
+              expect(diff).to be_diffed_as(expected_diff)
+            end
+          end
         end
       end
     end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -575,8 +575,8 @@ module RSpec
 
           context "with nested hash" do
             it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
-              actual = { :an_key => "dummy", :fixed => "fixed", :nested => { :name => "foo", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" } }
-              expected = { :an_key => anything, :fixed => "fixed", :nested => { :name => "foo", :trigger => "wrong", :anything_key => anything } }
+              actual = { :an_key => "dummy", :fixed => "fixed", :nested => { :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name => "foo", :trigger => "trigger" } }
+              expected = { :an_key => anything, :fixed => "fixed", :nested => { :anything_key => anything, :name => "foo", :trigger => "wrong" } }
               diff = differ.diff(actual, expected)
               expected_diff = dedent(<<-'EOD')
                 |
@@ -596,15 +596,15 @@ module RSpec
               actual = {
                 :an_key => "dummy", :fixed => "fixed",
                 :nested => {
-                  :nested_anything_key => "9930ddcb-1cfe-4de1-a481-ca6b17d41ed8",
-                  :subnested => { :name => "foo", :trigger => "trigger", :subnested_anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+                  :subnested => { :name => "foo", :trigger => "trigger", :subnested_anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" },
+                  :nested_anything_key => "9930ddcb-1cfe-4de1-a481-ca6b17d41ed8"
                 }
               }
               expected = {
                 :an_key => anything, :fixed => "fixed",
                 :nested => {
-                  :nested_anything_key => anything,
-                  :subnested => { :name => "foo", :trigger => "wrong", :subnested_anything_key => anything }
+                  :subnested => { :name => "foo", :trigger => "wrong", :subnested_anything_key => anything },
+                  :nested_anything_key => anything
                 }
               }
               diff = differ.diff(actual, expected)


### PR DESCRIPTION
Hi

I'd like to give you some context about this PR.

## TL; DR

See #551 , it is annoying to see the noise added by `anything` matcher on diffs and I wanted to fix that. I initially thought the solution was trivial, but I quickly found out I was wrong when I began reading the `Diff` class: there is a lot happening under the hood. I know there are some limitations to the Differ, and I understand there is a lot to change. This PR is a proposal, I don't know if my solution is too hacky, and I'd like to receive some feedback in order to solve this problem. 

Before:
```
@@ -1,4 +1,4 @@
-:an_key => anything,
+:an_key => "dummy",
 :fixed => "fixed",
-:nested => {:anything_key=>anything, :name=>"foo", :trigger=>"wrong"},
+:nested => {:anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name=>"foo", :trigger=>"trigger"},
```

After:
```
@@ -1,4 +1,4 @@
 :an_key => "dummy",
 :fixed => "fixed",
-:nested => {:anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name=>"foo", :trigger=>"wrong"},
+:nested => {:anything_key=>"bcdd0399-1cfe-4de1-a481-ca6b17d41ed8", :name=>"foo", :trigger=>"trigger"},
```

## Context

I am currently working on a RoR project that uses Jbuilder to render JSON data that I am delivering on the endpoints of my API.

I am testing my `.jbuilder` files with `type: view` RSpec tests, and I have a lot of `.json` fixture files I am loading and using on my test files as expected values.

## The problem this PR addresses.

My plan is to use these fixture files to kill two birds with one stone. On one side, I am comparing those fixture files with the JSON rendered by the `.jbuilder` files, and on the other side I am using those fixture files as mocks to share with the frontend developers, so they will have the data necessary to write their React application.

The plan is: if somebody in the backend changes a jbuilder, the tests will complain and I will remember to change the corresponding JSON fixture. This way, I will always have the JSON fixtures used by the frontend developers in sync with the backend rendered files. Frontend developers often need to work with data they don't know how to create on their local machines (because they do know React or Vue, but don't know the Rails framework)

In order to achieve the results of my plan, I ~ needed ~ to scrub some fields of my JSON fixture files using the `anything` fuzzy matcher. An example of fields I often need to scrub are the `id`, `created_at` and `updated_at` values.

I quickly discovered this annoying issue described on #551 : whenever I missed something that should make the test fail and render the diff in STDOUT, I found out the key-value pairs in my expected var with a `anything` matcher will add noise to the diff message, obfuscating which key actually differs from the expectation.

 ## My approach.
 
 My first idea was: _before_ the place in the source code that renders the diff string between `actual` and `expected` vars, I can add a stage where I'll search _every_ key-value pair that has an `anything` object as value in the `expected` variable, and _replace_ the `anything` value with the value found on the `actual` var I am testing.
 
 Hopefully the commits of this PR will show you what I mean. First commit consists in an implementation that will work with a Hash with no nested hashes, second commit will use recursivity to extend the solution to a hash object with nested hashes. 
 
## My reasons.

When I started writing the code to implement my idea, I've got a lot of questions: Can I just mutate the expected var? Shouldn't I get a notice message by the diff remembering that I've used the `anything` fuzzy matcher in my test? can I _just copy_ the actual value in the expected var? Am I lying when I am doing that?

My answer to these questions was: If I _decide_ to use the fuzzy matcher `anything` on a key-value pair in a hash object in my test, it implies I _do not care about seeing the `anything` in my diff_ . Because it is a wild card, because the `anything` fuzzy matcher should _morph_ into the real value on my actual variable.

I know this solution is hacky.... but it works! It gets rid of the noise generated by the `anything` fuzzy matcher. I tried to use the [super_diff](https://github.com/mcmire/super_diff)  gem, but it has the same problem.

I am sure the code I wrote can be improved and be more concise (as surely could be the text on this PR, lol), and I thought about extending the fix to cover `Array` objects. But I wanted to know your opinion about this issue before continuing with this. Can I use a recursive function this way? What impact on performance will have my lines of code in this extra stage I am adding? As Aristotle said: every scientific investigation should begin by gathering the opinion of the wise people (ie, the people that earlier on thought and worked on the problem I will begin to work right now).

I always liked the "diff" concept. And I am willing to continue collaborating on enhancing the diff tool. I've seen @mcmire wrote [this guide about RSpec](https://github.com/mcmire/super_diff/blob/main/docs/contributors/architecture/how-rspec-works.md#what-rspec-does), but I have not digged on the article yet. I am doing baby steps. Every feedback is appreciated.

Best.