### PR TITLE
Show a diff for comparisons of arrays of one-line strings

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -13,11 +13,9 @@ module RSpec
       def diff(actual, expected)
         diff = ""
 
-        unless actual.nil? || expected.nil?
+        unless actual.nil? || expected.nil? || pointless_diff?(actual, expected)
           if all_strings?(actual, expected)
-            if any_multiline_strings?(actual, expected)
-              diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
-            end
+            diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
           elsif no_procs?(actual, expected) && no_numbers?(actual, expected)
             diff = diff_as_object(actual, expected)
           end
@@ -81,8 +79,8 @@ module RSpec
         safely_flatten(args).all? { |a| String === a }
       end
 
-      def any_multiline_strings?(*args)
-        all_strings?(*args) && safely_flatten(args).any? { |a| multiline?(a) }
+      def pointless_diff?(actual, expected)
+        String === actual && String === expected && !multiline?(actual) && !multiline?(expected)
       end
 
       def no_numbers?(*args)

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -116,6 +116,36 @@ module RSpec
           expect { differ.diff(actual, expected) }.not_to change { differ_ivars }
         end
 
+        it 'returns the expected diff for arrays of single-line strings' do
+          expected = ["foo"]
+          actual   = ["foo", "bar"]
+
+          expected_diff = dedent(<<-'EOS')
+            |
+            |@@ -1,2 +1,3 @@
+            | foo
+            |+bar
+            |
+          EOS
+          diff = differ.diff(actual, expected)
+          expect(diff).to eq(expected_diff)
+        end
+
+        it 'does not give an empty string for single-element arrays of single-line strings' do
+          expected = ["foo"]
+          actual   = ["bar"]
+
+          expected_diff = dedent(<<-'EOS')
+            |
+            |@@ -1 +1 @@
+            |-foo
+            |+bar
+            |
+          EOS
+          diff = differ.diff(actual, expected)
+          expect(diff).to eq(expected_diff)
+        end
+
         def differ_ivars
           Hash[ differ.instance_variables.map do |ivar|
             [ivar, differ.instance_variable_get(ivar)]


### PR DESCRIPTION
A long time ago, a fellow notice a regression in the [behavior of diffing](https://github.com/rspec/rspec/issues/78). Roughly speaking, `expect(["foo"]).to eq(["foo", "baz"])` doesn't print a "Diff" section of output. But `expect(["foo"]).to eq(["foo", "baz\n"])` _does_. And that seems like an odd distinction to make! To the code mines!

I had to trace this across the move from rspec-expectations into rspec-support, but it was originally introduced [here](https://github.com/rspec/rspec-expectations/commit/044b0a6ff1), which was motivated by [this issue](https://github.com/rspec/rspec-expectations/issues/115). That seems like a reasonable goal, and we do actually have some tests enforcing it already (though they're a little entangled with the encoding specs - I can add another test specific to this purpose if you like). The effect it had on diffing _arrays_ of strings seems incidental though, a result of the way we flatten the arrays to test them, rather than checking them individually.

So! Break that check out ahead, and make it a bit clearer - add `pointless_diff?`, which tests that both arguments are Strings, and that neither string is multiline; for that case, skip adding the diff like before, but drop the 'multiline' test that _was_ skipping.