### PR TITLE
Override RSpec::Support::StdErrSplitter#clone

### DIFF
--- a/lib/rspec/support/spec/stderr_splitter.rb
+++ b/lib/rspec/support/spec/stderr_splitter.rb
@@ -21,6 +21,10 @@ module RSpec
         @orig_stderr.__send__(name, *args, &block)
       end
 
+      def clone
+        StdErrSplitter.new(@orig_stderr.clone)
+      end
+
       def ==(other)
         @orig_stderr == other
       end

--- a/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -95,4 +95,8 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
     end
   end
 
+  # Otherwise, Splitter#reopen _also_ reopens the clone, unlike with actual STDERR
+  it 'does not reuse the stream when cloned' do
+    expect(splitter.to_io).not_to eq(splitter.clone.to_io)
+  end
 end

--- a/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
 
   # This is essentially what the `to_stderr_from_any_process` matcher attempts
   # to do in CaptureStreamToTempfile.
-  it 'is able to restore the stream from a cloned StdErrSplitter' do
+  it 'is able to restore the stream from a cloned StdErrSplitter', :pending => RSpec::Support::Ruby.jruby? do
     cloned = $stderr.clone
     expect($stderr.to_io).not_to be_a(File)
 


### PR DESCRIPTION
With the default definition, cloning a StdErrSplitter results in the clone having the same @orig_stderr instance as the original Splitter has, which means that reopening either Splitter affects both (since the underlying stream is not cloned).

This is different from the behavior of an actual stream, in a way that causes a problem for the CaptureStreamToTempfile in rspec-matchers (used by the `output.to_stderr_from_any_process` matcher), because it clones the original stream to store it for restoration, and then `reopen`s it at a Tempfile temporarily. But then when it goes back to _restore_ the stream, it doesn't actually do so, since the clone's stream reference is the same instance as the original Splitter has - it just reopens it with the Tempfile again.

This is a supporting PR for https://github.com/rspec/rspec-expectations/pull/1460 - before I can make compound `to_stderr_from_any_process` matchers work, I need the "restore the stream after capturing" behavior to _actually work_.