### PR TITLE
Fix diff output when a fuzzy finder anything is inside an expected hash

### DIFF
--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -58,8 +58,8 @@ module RSpec
       end
       # rubocop:enable Metrics/MethodLength
 
-      def diff_hashes_as_object(actual, expected)
-        if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
+      if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
+        def diff_hashes_as_object(actual, expected)
           expected_to_diff =
             expected.reduce({}) do |hash, (key, value)|
               if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === value
@@ -71,7 +71,9 @@ module RSpec
             end
 
           diff_as_object(actual, expected_to_diff)
-        else
+        end
+      else
+        def diff_hashes_as_object(actual, expected)
           diff_as_object(actual, expected)
         end
       end

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -19,7 +19,7 @@ module RSpec
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
             end
           elsif no_procs_and_no_numbers?(actual, expected)
-            if Hash === expected && hash_with_anything?(expected)
+            if (RUBY_VERSION.to_f > 1.8) && hash_with_anything?(expected)
               diff = diff_as_object_with_anything(actual, expected)
             else
               diff = diff_as_object(actual, expected)
@@ -85,7 +85,7 @@ module RSpec
     private
 
       def hash_with_anything?(arg)
-        safely_flatten(arg).any? { |a| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === a }
+        Hash === arg && safely_flatten(arg).any? { |a| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === a }
       end
 
       def no_procs_and_no_numbers?(*args)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -59,10 +59,25 @@ module RSpec
       # rubocop:enable Metrics/MethodLength
 
       def diff_hashes_as_object(actual, expected)
-        expected.select { |_, v| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === v }.each_key do |k|
-          expected[k] = actual[k]
+        if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
+          anything_hash = expected.select { |_, v| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === v }
+
+          anything_hash.each_key do |k|
+            expected[k] = actual[k]
+          end
+
+          diff_string = diff_as_object(actual, expected)
+
+          if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
+            anything_hash.each do |k, v|
+              expected[k] = v
+            end
+          end
+
+          diff_string
+        else
+          diff_as_object(actual, expected)
         end
-        diff_as_object(actual, expected)
       end
 
       def diff_as_object(actual, expected)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -60,17 +60,16 @@ module RSpec
 
       if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
         def diff_hashes_as_object(actual, expected)
-          expected_to_diff =
-            expected.reduce({}) do |hash, (key, value)|
-              if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === value
-                hash[key] = actual[key]
-              else
+          actual_to_diff =
+            actual.reduce({}) do |hash, (key, value)|
+              if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === expected[key]
                 hash[key] = expected[key]
+              else
+                hash[key] = actual[key]
               end
               hash
             end
-
-          diff_as_object(actual, expected_to_diff)
+          diff_as_object(actual_to_diff, expected)
         end
       else
         def diff_hashes_as_object(actual, expected)

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -18,8 +18,12 @@ module RSpec
             if any_multiline_strings?(actual, expected)
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
             end
-          elsif no_procs?(actual, expected) && no_numbers?(actual, expected)
-            diff = diff_as_object(actual, expected)
+          elsif no_procs_and_no_numbers?(actual, expected)
+            if Hash === expected && hash_with_anything?(expected)
+              diff = diff_as_object_with_anything(actual, expected)
+            else
+              diff = diff_as_object(actual, expected)
+            end
           end
         end
 
@@ -56,6 +60,13 @@ module RSpec
       end
       # rubocop:enable Metrics/MethodLength
 
+      def diff_as_object_with_anything(actual, expected)
+        expected.select { |_, v| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === v }.each_key do |k|
+          expected[k] = actual[k]
+        end
+        diff_as_object(actual, expected)
+      end
+
       def diff_as_object(actual, expected)
         actual_as_string = object_to_string(actual)
         expected_as_string = object_to_string(expected)
@@ -72,6 +83,14 @@ module RSpec
       end
 
     private
+
+      def hash_with_anything?(arg)
+        safely_flatten(arg).any? { |a| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === a }
+      end
+
+      def no_procs_and_no_numbers?(*args)
+        no_procs?(args) && no_numbers?(args)
+      end
 
       def no_procs?(*args)
         safely_flatten(args).none? { |a| Proc === a }

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -61,7 +61,7 @@ module RSpec
       if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
         def diff_hashes_as_object(actual, expected)
           actual_to_diff =
-            actual.reduce({}) do |hash, (key, value)|
+            actual.keys.reduce({}) do |hash, key|
               if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === expected[key]
                 hash[key] = expected[key]
               else

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -92,7 +92,7 @@ module RSpec
         no_procs?(args) && no_numbers?(args)
       end
 
-      def no_procs?(*args)
+      def no_procs?(args)
         safely_flatten(args).none? { |a| Proc === a }
       end
 
@@ -104,7 +104,7 @@ module RSpec
         all_strings?(*args) && safely_flatten(args).any? { |a| multiline?(a) }
       end
 
-      def no_numbers?(*args)
+      def no_numbers?(args)
         safely_flatten(args).none? { |a| Numeric === a }
       end
 

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -68,10 +68,8 @@ module RSpec
 
           diff_string = diff_as_object(actual, expected)
 
-          if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
-            anything_hash.each do |k, v|
-              expected[k] = v
-            end
+          anything_hash.each do |k, v|
+            expected[k] = v
           end
 
           diff_string

--- a/lib/rspec/support/differ.rb
+++ b/lib/rspec/support/differ.rb
@@ -60,19 +60,17 @@ module RSpec
 
       def diff_hashes_as_object(actual, expected)
         if defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher)
-          anything_hash = expected.select { |_, v| RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === v }
+          expected_to_diff =
+            expected.reduce({}) do |hash, (key, value)|
+              if RSpec::Mocks::ArgumentMatchers::AnyArgMatcher === value
+                hash[key] = actual[key]
+              else
+                hash[key] = expected[key]
+              end
+              hash
+            end
 
-          anything_hash.each_key do |k|
-            expected[k] = actual[k]
-          end
-
-          diff_string = diff_as_object(actual, expected)
-
-          anything_hash.each do |k, v|
-            expected[k] = v
-          end
-
-          diff_string
+          diff_as_object(actual, expected_to_diff)
         else
           diff_as_object(actual, expected)
         end
@@ -100,7 +98,7 @@ module RSpec
       end
 
       def all_hashes?(actual, expected)
-        defined?(RSpec::Mocks::ArgumentMatchers::AnyArgMatcher) && (Hash === actual) && (Hash === expected)
+        (Hash === actual) && (Hash === expected)
       end
 
       def all_strings?(*args)

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -6,7 +6,7 @@ require 'rspec/support/spec/string_matcher'
 
 module RSpec
   module Support
-    RSpec.describe Differ do
+    RSpec.describe "Differ" do
       include Spec::DiffHelpers
 
       describe '#diff' do

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -556,21 +556,24 @@ module RSpec
           end
         end
 
-        describe "fuzzy matcher anything" do
-          it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
-            actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
-            expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
-            diff = differ.diff(actual, expected)
-            expected_diff = dedent(<<-'EOD')
-              |
-              |@@ -1,4 +1,4 @@
-              | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
-              | :fixed => "fixed",
-              |-:trigger => "wrong",
-              |+:trigger => "trigger",
-              |
-            EOD
-            expect(diff).to be_diffed_as(expected_diff)
+        unless RUBY_VERSION == '1.8.7'
+          describe "fuzzy matcher anything" do
+            it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+              actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+              expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
+              diff = differ.diff(actual, expected)
+              expected_diff = dedent(<<-'EOD')
+                |
+                |@@ -1,4 +1,4 @@
+                | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
+                | :fixed => "fixed",
+                |-:trigger => "wrong",
+                |+:trigger => "trigger",
+                |
+              EOD
+              # puts diff
+              expect(diff).to be_diffed_as(expected_diff)
+            end
           end
         end
       end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -564,7 +564,7 @@ module RSpec
             expected_diff = dedent(<<-'EOD')
               |
               |@@ -1,4 +1,4 @@
-              | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
+              | :anything_key => anything,
               | :fixed => "fixed",
               |-:trigger => "wrong",
               |+:trigger => "trigger",

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -555,6 +555,24 @@ module RSpec
             expect(differ.diff(false, true)).to_not be_empty
           end
         end
+
+        describe "fuzzy matcher anything" do
+          it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+            actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+            expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
+            diff = differ.diff(actual, expected)
+            expected_diff = dedent(<<-'EOD')
+              |
+              |@@ -1,4 +1,4 @@
+              | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
+              | :fixed => "fixed",
+              |-:trigger => "wrong",
+              |+:trigger => "trigger",
+              |
+            EOD
+            expect(diff).to be_diffed_as(expected_diff)
+          end
+        end
       end
     end
   end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -556,24 +556,21 @@ module RSpec
           end
         end
 
-        unless RUBY_VERSION == '1.8.7'
-          describe "fuzzy matcher anything" do
-            it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
-              actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
-              expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
-              diff = differ.diff(actual, expected)
-              expected_diff = dedent(<<-'EOD')
-                |
-                |@@ -1,4 +1,4 @@
-                | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
-                | :fixed => "fixed",
-                |-:trigger => "wrong",
-                |+:trigger => "trigger",
-                |
-              EOD
-              # puts diff
-              expect(diff).to be_diffed_as(expected_diff)
-            end
+        describe "fuzzy matcher anything" do
+          it "outputs only key value pair that triggered diff, anything_key should absorb actual value" do
+            actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+            expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
+            diff = differ.diff(actual, expected)
+            expected_diff = dedent(<<-'EOD')
+              |
+              |@@ -1,4 +1,4 @@
+              | :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
+              | :fixed => "fixed",
+              |-:trigger => "wrong",
+              |+:trigger => "trigger",
+              |
+            EOD
+            expect(diff).to be_diffed_as(expected_diff)
           end
         end
       end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -572,6 +572,12 @@ module RSpec
             EOD
             expect(diff).to be_diffed_as(expected_diff)
           end
+          it "checks the 'expected' var continues having the 'anything' fuzzy matcher, it has not mutated" do
+            actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
+            expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
+            differ.diff(actual, expected)
+            expect(expected).to eq({ :fixed => "fixed", :trigger => "wrong", :anything_key => anything })
+          end
         end
       end
     end

--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -572,6 +572,7 @@ module RSpec
             EOD
             expect(diff).to be_diffed_as(expected_diff)
           end
+
           it "checks the 'expected' var continues having the 'anything' fuzzy matcher, it has not mutated" do
             actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
             expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }


### PR DESCRIPTION
This is a simplified version of PR #596 , it solves the issue #551 "Diff reports confusing output when used with "fuzzy" matchers like `anything` "

This PR will fix only `anything` values associated to top level keys of a hash. It will not work with nested hashes.

Example output *BEFORE* changes in this PR:

```
@@ -1,4 +1,4 @@
-:anything_key => anything,
+:anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8",
 :fixed => "fixed",
-:trigger => "wrong",
+:trigger => "trigger",
```

Example output *AFTER* changes in this PR:

```
@@ -1,4 +1,4 @@
 :anything_key => anything,
 :fixed => "fixed",
-:trigger => "wrong",
+:trigger => "trigger",
```

