### PR TITLE
Fix warnings on Ruby 3.4.0

### DIFF
--- a/spec/rspec/support/differ_spec.rb
+++ b/spec/rspec/support/differ_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'spec_helper'
-require 'ostruct'
 require 'timeout'
 require 'rspec/support/spec/string_matcher'
 

--- a/spec/rspec/support_spec.rb
+++ b/spec/rspec/support_spec.rb
@@ -164,7 +164,7 @@ module RSpec
 
       context 'with an object having a singleton class' do
         let(:object) do
-          object = 'foo'
+          object = String.new('foo')
 
           def object.some_method
           end


### PR DESCRIPTION
Fixes:
- a string literal warning by using an non literal string
- removes an uneeded require in specs